### PR TITLE
Fetch initial dashboard data

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -42,20 +42,20 @@ const sampleData = {
 
 const Dashboard: React.FC = () => {
   const [selectedTopic, setSelectedTopic] = useState('Impact Overview');
-  const [dashboards, setDashboards] = useState<any[]>([]);
+  const [dashboard, setDashboard] = useState<any | null>(null);
 
   useEffect(() => {
-    const fetchDashboards = async () => {
+    const fetchDashboard = async () => {
       try {
         const loadedDashboards = await dashboardService.listDashboards();
         if (loadedDashboards && loadedDashboards.length > 0) {
-          setDashboards(loadedDashboards);
+          setDashboard(loadedDashboards[0]);
         }
       } catch (e) {
-        console.error('Failed to load dashboards', e);
+        console.error('Failed to load dashboard', e);
       }
     };
-    fetchDashboards();
+    fetchDashboard();
   }, []);
 
   const renderContent = (dashboardData: any) => {
@@ -163,14 +163,14 @@ const Dashboard: React.FC = () => {
         </Select>
       </div>
       
-      {dashboards.length > 0
-        ? dashboards.map((dashboard) => (
-            <div key={dashboard.id} className="space-y-4">
-              <h2 className="text-2xl font-bold text-gray-800">{dashboard.title}</h2>
-              {renderContent(dashboard.chart_data || sampleData)}
-            </div>
-          ))
-        : renderContent(sampleData)}
+      {dashboard ? (
+        <div className="space-y-4">
+          <h2 className="text-2xl font-bold text-gray-800">{dashboard.title}</h2>
+          {renderContent(dashboard.chart_data || sampleData)}
+        </div>
+      ) : (
+        renderContent(sampleData)
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- load the first dashboard from the API
- show charts using that dashboard's data on the Dashboard page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684a6a54bf10832b8991ca409046e123