### PR TITLE
Use uploaded data for dashboards

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -75,8 +75,14 @@ const Dashboard: React.FC = () => {
                     <XAxis dataKey="name" />
                     <YAxis />
                     <Tooltip />
-                    <Bar dataKey="before" fill="#f3f4f6" />
-                    <Bar dataKey="after" fill="#20c6cd" />
+                    {dashboardData.impact && dashboardData.impact[0]?.before !== undefined ? (
+                      <>
+                        <Bar dataKey="before" fill="#f3f4f6" />
+                        <Bar dataKey="after" fill="#20c6cd" />
+                      </>
+                    ) : (
+                      <Bar dataKey="value" fill="#20c6cd" />
+                    )}
                   </BarChart>
                 </ResponsiveContainer>
               </CardContent>
@@ -94,8 +100,14 @@ const Dashboard: React.FC = () => {
                     <XAxis dataKey="month" />
                     <YAxis />
                     <Tooltip />
-                    <Line type="monotone" dataKey="beneficiaries" stroke="#20c6cd" strokeWidth={3} />
-                    <Line type="monotone" dataKey="impact" stroke="#000000" strokeWidth={3} />
+                    {dashboardData.timeline && dashboardData.timeline[0]?.beneficiaries !== undefined ? (
+                      <>
+                        <Line type="monotone" dataKey="beneficiaries" stroke="#20c6cd" strokeWidth={3} />
+                        <Line type="monotone" dataKey="impact" stroke="#000000" strokeWidth={3} />
+                      </>
+                    ) : (
+                      <Line type="monotone" dataKey="value" stroke="#20c6cd" strokeWidth={3} />
+                    )}
                   </LineChart>
                 </ResponsiveContainer>
               </CardContent>


### PR DESCRIPTION
## Summary
- persist processed dataset in `DataService`
- analyze uploaded records in `DashboardService`
- render fallback charts in `Dashboard` page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684a6ade3228832ba2994516e0431171