### PR TITLE
Update dashboard service to use enum

### DIFF
--- a/backend/app/services/dashboard_service.py
+++ b/backend/app/services/dashboard_service.py
@@ -4,7 +4,7 @@ from typing import List, Dict, Any
 import json
 import pandas as pd
 from ..models.dashboard import Dashboard
-from ..models.data_upload import DataUpload
+from ..models.data_upload import DataUpload, UploadStatus
 from ..schemas.dashboard import DashboardCreate
 
 class DashboardService:
@@ -14,7 +14,10 @@ class DashboardService:
         # Use the latest completed upload for dashboard generation
         latest_upload = (
             db.query(DataUpload)
-            .filter(DataUpload.user_id == user_id, DataUpload.status == "completed")
+            .filter(
+                DataUpload.user_id == user_id,
+                DataUpload.status == UploadStatus.completed
+            )
             .order_by(DataUpload.created_at.desc())
             .first()
         )

--- a/backend/tests/test_dashboard_service.py
+++ b/backend/tests/test_dashboard_service.py
@@ -4,13 +4,13 @@ import pytest
 
 from backend.app.services.dashboard_service import DashboardService
 from backend.app.schemas.dashboard import DashboardCreate
-from backend.app.models.data_upload import DataUpload
+from backend.app.models.data_upload import DataUpload, UploadStatus
 
 class DummyDataUpload:
     def __init__(self, user_id, created_at, metadata):
         self.user_id = user_id
         self.created_at = created_at
-        self.status = "completed"
+        self.status = UploadStatus.completed
         self.upload_metadata = metadata
 
 class DummyQuery:


### PR DESCRIPTION
## Summary
- use `UploadStatus.completed` instead of hard-coded string when selecting the newest upload
- update tests to use `UploadStatus` enum

## Testing
- `PYTHONPATH=. pytest backend/tests -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684abcedd0f4832b963e149b80c99632