### PR TITLE
feat: integrate external auth and role-based access

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -45,6 +45,15 @@ Required environment variables:
 - `OPENAI_API_KEY`: OpenAI API key for LLM features
 - `XERO_CLIENT_ID` & `XERO_CLIENT_SECRET`: Xero OAuth credentials
 - `GOOGLE_CLIENT_ID` & `GOOGLE_CLIENT_SECRET`: Google OAuth credentials
+- `AUTH0_DOMAIN` & `AUTH0_AUDIENCE`: Auth0 settings for JWT verification (optional)
+- `FIREBASE_PROJECT_ID`: Firebase project ID for token verification (optional)
+
+### Authentication Setup
+
+The backend verifies incoming JWTs using either Auth0 or Firebase public keys.
+Provide the corresponding environment variables above and ensure tokens include a
+`roles` claim. Role-based access control is enforced on sensitive routes such as
+`POST /api/v1/integrations/sync`, which requires an `admin` role.
 
 ### 4. Run the Backend
 

--- a/backend/app/api/routes/integrations.py
+++ b/backend/app/api/routes/integrations.py
@@ -3,7 +3,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 from ...database import get_db
 from ...models.user import User
-from ...api.deps import get_current_user
+from ...api.deps import get_current_user, require_roles
 from ...services.integration_service import IntegrationService
 
 router = APIRouter(prefix="/integrations", tags=["integrations"])
@@ -60,7 +60,7 @@ async def get_integration_status(
 
 @router.post("/sync")
 async def sync_integrations(
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_roles(["admin"])),
     db: Session = Depends(get_db)
 ):
     integration_service = IntegrationService()

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,6 +1,6 @@
 
 from pydantic_settings import BaseSettings
-from typing import List
+from typing import List, Optional
 
 class Settings(BaseSettings):
     # Database
@@ -27,6 +27,11 @@ class Settings(BaseSettings):
     
     # Security
     secret_key: str
+
+    # External Auth Providers
+    auth0_domain: Optional[str] = None
+    auth0_audience: Optional[str] = None
+    firebase_project_id: Optional[str] = None
     
     # CORS
     allowed_origins: str = "http://localhost:3000,http://localhost:5173"


### PR DESCRIPTION
## Summary
- verify JWTs using Auth0 or Firebase public keys
- support role-based access and protect integrations sync with admin role
- document Auth0/Firebase setup and role claims

## Testing
- `pytest backend/tests` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_68a6e7ad11c0832b8d382f5905c745d8