### PR TITLE
Add PDF report generation and download route

### DIFF
--- a/backend/app/api/routes/reports.py
+++ b/backend/app/api/routes/reports.py
@@ -1,5 +1,6 @@
 
 from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import FileResponse
 from sqlalchemy.orm import Session
 from ...database import get_db
 from ...models.user import User
@@ -51,13 +52,16 @@ async def get_report(
 @router.get("/{report_id}/download")
 async def download_report(
     report_id: int,
-    format: str = "pdf",
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db)
 ):
     report_service = ReportService()
     try:
-        file_path = await report_service.download_report(report_id, current_user.id, format, db)
-        return {"download_url": file_path}
+        pdf_path = await report_service.generate_pdf(report_id, current_user.id, db)
+        return FileResponse(
+            pdf_path,
+            media_type="application/pdf",
+            filename=f"report_{report_id}.pdf",
+        )
     except Exception as e:
         raise HTTPException(status_code=400, detail=str(e))

--- a/backend/app/services/report_service.py
+++ b/backend/app/services/report_service.py
@@ -1,3 +1,107 @@
+from tempfile import NamedTemporaryFile
+from typing import Any, Dict, Optional
+
+from sqlalchemy.orm import Session
+
+from .dashboard_service import DashboardService
+from ..models.report import Report
+
+
 class ReportService:
-    def __init__(self):
-        pass
+    def __init__(self) -> None:
+        self.dashboard_service = DashboardService()
+
+    async def generate_report(
+        self, user_id: int, framework: str, title: str, db: Session
+    ) -> Report:
+        """Create a basic report record."""
+
+        report = Report(
+            user_id=user_id,
+            title=title,
+            framework=framework,
+            metrics={},
+            visualizations={},
+        )
+        db.add(report)
+        db.commit()
+        db.refresh(report)
+        return report
+
+    async def get_report(
+        self, report_id: int, user_id: int, db: Session
+    ) -> Optional[Report]:
+        """Retrieve a report for a specific user."""
+
+        return (
+            db.query(Report)
+            .filter(Report.id == report_id, Report.user_id == user_id)
+            .first()
+        )
+
+    async def generate_pdf(
+        self, report_id: int, user_id: int, db: Session
+    ) -> str:
+        """Generate a PDF report including metrics and charts."""
+
+        from reportlab.lib.pagesizes import letter
+        from reportlab.pdfgen import canvas
+        from reportlab.graphics.charts.barcharts import VerticalBarChart
+        from reportlab.graphics.shapes import Drawing
+        from reportlab.graphics import renderPDF
+
+        report = await self.get_report(report_id, user_id, db)
+        if not report:
+            raise ValueError("Report not found")
+
+        metrics: Dict[str, Any] = report.metrics or {}
+        charts: Dict[str, Any] = report.visualizations or {}
+
+        dashboards = await self.dashboard_service.get_user_dashboards(user_id, db)
+        if dashboards:
+            charts.update(dashboards[0].chart_data or {})
+
+        pdf_file = NamedTemporaryFile(delete=False, suffix=".pdf")
+        c = canvas.Canvas(pdf_file.name, pagesize=letter)
+        width, height = letter
+        y = height - 50
+
+        c.setFont("Helvetica-Bold", 16)
+        c.drawString(40, y, report.title)
+        y -= 30
+
+        c.setFont("Helvetica", 12)
+        if metrics:
+            c.drawString(40, y, "Metrics")
+            y -= 20
+            for name, value in metrics.items():
+                c.drawString(60, y, f"{name}: {value}")
+                y -= 15
+            y -= 10
+
+        impact_data = charts.get("impact")
+        if impact_data:
+            c.drawString(40, y, "Impact Chart")
+            y -= 170
+            drawing = Drawing(400, 150)
+            data = [item.get("value", 0) for item in impact_data]
+            names = [item.get("name", "") for item in impact_data]
+            chart = VerticalBarChart()
+            chart.x = 0
+            chart.y = 0
+            chart.height = 150
+            chart.width = 400
+            chart.data = [data]
+            chart.categoryAxis.categoryNames = names
+            drawing.add(chart)
+            renderPDF.draw(drawing, c, 40, y)
+            y -= 10
+
+        c.showPage()
+        c.save()
+        pdf_file.close()
+
+        report.report_url = pdf_file.name
+        db.commit()
+
+        return pdf_file.name

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -20,3 +20,4 @@ requests==2.31.0
 pydantic==2.5.0
 pydantic-settings==2.1.0
 pydantic[email]
+reportlab==3.6.12


### PR DESCRIPTION
## Summary
- add ReportService.generate_pdf to build PDF reports using ReportLab, embedding metrics and charts
- expose `/reports/{id}/download` route that streams the generated PDF
- include ReportLab dependency for backend

## Testing
- `pip install reportlab==3.6.12` *(failed: Cannot connect to proxy)*
- `pip install pytest-asyncio` *(failed: Cannot connect to proxy)*
- `PYTHONPATH=$PWD pytest backend/tests -q` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_68a6e7a57424832ba0d06f9393a396ce