### PR TITLE
feat: add async data ingestion and configurable dashboard topics

### DIFF
--- a/backend/alembic/versions/3c280994c450_add_dashboard_topic_model.py
+++ b/backend/alembic/versions/3c280994c450_add_dashboard_topic_model.py
@@ -1,0 +1,22 @@
+"""add dashboard topic model"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '3c280994c450'
+down_revision = '2b3f9d1c92a1'
+branch_labels = None
+depends_on = None
+
+def upgrade() -> None:
+    op.create_table(
+        'dashboard_topics',
+        sa.Column('id', sa.Integer(), primary_key=True, index=True),
+        sa.Column('name', sa.String(), nullable=False, unique=True),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.func.now())
+    )
+
+
+def downgrade() -> None:
+    op.drop_table('dashboard_topics')

--- a/backend/app/api/routes/dashboards.py
+++ b/backend/app/api/routes/dashboards.py
@@ -11,18 +11,9 @@ from ...services.dashboard_service import DashboardService
 router = APIRouter(prefix="/dashboards", tags=["dashboards"])
 
 @router.get("/topics")
-async def get_dashboard_topics():
-    # Available dashboard topics
-    topics = [
-        "Impact Overview",
-        "SDG Alignment", 
-        "Financial Performance",
-        "Beneficiary Demographics",
-        "Program Outcomes",
-        "Geographic Distribution",
-        "Time Series Analysis",
-        "Comparative Analysis"
-    ]
+async def get_dashboard_topics(db: Session = Depends(get_db)):
+    service = DashboardService()
+    topics = await service.get_topics(db)
     return {"topics": topics}
 
 @router.post("/generate", response_model=DashboardResponse)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,6 +1,7 @@
 from .user import User
 from .data_upload import DataUpload
 from .dashboard import Dashboard
+from .dashboard_topic import DashboardTopic
 from .report import Report
 from .project import Project
 from .activity import Activity

--- a/backend/app/models/dashboard_topic.py
+++ b/backend/app/models/dashboard_topic.py
@@ -1,0 +1,12 @@
+from sqlalchemy import Column, Integer, String, DateTime
+from sqlalchemy.sql import func
+
+from ..database import Base
+
+
+class DashboardTopic(Base):
+    __tablename__ = "dashboard_topics"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, unique=True, nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())

--- a/backend/app/schemas/data.py
+++ b/backend/app/schemas/data.py
@@ -10,6 +10,7 @@ class DataUploadRequest(BaseModel):
 class DataUploadResponse(BaseModel):
     id: int
     file_name: Optional[str]
+    file_path: Optional[str]
     source_type: str
     status: str
     row_count: Optional[int]

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -2,6 +2,7 @@
 from .auth_service import AuthService
 from .data_service import DataService
 from .dashboard_service import DashboardService
+from .ingestion_service import IngestionService
 from .report_service import ReportService
 from .integration_service import IntegrationService
 from .investor_service import InvestorService
@@ -9,7 +10,8 @@ from .investor_service import InvestorService
 __all__ = [
     "AuthService",
     "DataService",
-    "DashboardService", 
+    "DashboardService",
+    "IngestionService",
     "ReportService",
     "IntegrationService",
     "InvestorService"

--- a/backend/app/services/dashboard_service.py
+++ b/backend/app/services/dashboard_service.py
@@ -2,6 +2,7 @@
 from sqlalchemy.orm import Session
 from typing import List, Dict, Any
 from ..models.dashboard import Dashboard
+from ..models.dashboard_topic import DashboardTopic
 from ..models.data_upload import DataUpload, UploadStatus
 from ..models.project import Project
 from ..schemas.dashboard import DashboardCreate
@@ -45,6 +46,28 @@ class DashboardService:
             db.added = dashboard
 
         return dashboard
+
+    async def get_topics(self, db: Session) -> List[str]:
+        """Return available dashboard topics from the database, seeding defaults if empty"""
+
+        topics = db.query(DashboardTopic).all()
+        if not topics:
+            default_topics = [
+                "Impact Overview",
+                "SDG Alignment",
+                "Financial Performance",
+                "Beneficiary Demographics",
+                "Program Outcomes",
+                "Geographic Distribution",
+                "Time Series Analysis",
+                "Comparative Analysis",
+            ]
+            for name in default_topics:
+                db.add(DashboardTopic(name=name))
+            db.commit()
+            topics = db.query(DashboardTopic).all()
+
+        return [t.name for t in topics]
     
     async def _generate_chart_data(self, user_id: int, topics: List[str], db: Session) -> Dict[str, Any]:
         """Aggregate chart data for a user by joining projects with their metrics"""

--- a/backend/app/services/ingestion_service.py
+++ b/backend/app/services/ingestion_service.py
@@ -1,0 +1,63 @@
+import json
+from pathlib import Path
+from sqlalchemy.orm import Session
+
+from ..models.data_upload import DataUpload, UploadStatus
+from ..models.project import Project
+from ..models.activity import Activity
+from ..models.outcome import Outcome
+from ..models.metric import Metric
+
+
+class IngestionService:
+    async def ingest_upload(self, upload_id: int, db: Session) -> None:
+        """Read the stored upload file and persist project/activity/outcome/metric data."""
+
+        upload = db.query(DataUpload).filter(DataUpload.id == upload_id).first()
+        if not upload or not upload.file_path:
+            return
+
+        try:
+            upload.status = UploadStatus.processing
+            db.commit()
+
+            path = Path(upload.file_path)
+            if not path.exists():
+                raise FileNotFoundError(f"Upload file not found: {path}")
+
+            with path.open("r", encoding="utf-8") as f:
+                data = json.load(f)
+
+            row_count = 0
+            for project_data in data:
+                project = Project(user_id=upload.user_id, name=project_data.get("name", "Unnamed Project"))
+                db.add(project)
+                db.flush()
+                row_count += 1
+
+                for activity_data in project_data.get("activities", []):
+                    activity = Activity(project_id=project.id, name=activity_data.get("name", "Activity"))
+                    db.add(activity)
+                    db.flush()
+
+                    for outcome_data in activity_data.get("outcomes", []):
+                        outcome = Outcome(activity_id=activity.id, name=outcome_data.get("name", "Outcome"))
+                        db.add(outcome)
+                        db.flush()
+
+                        for metric_data in outcome_data.get("metrics", []):
+                            metric = Metric(
+                                outcome_id=outcome.id,
+                                name=metric_data.get("name", "metric"),
+                                value=metric_data.get("value"),
+                            )
+                            db.add(metric)
+                            db.flush()
+
+            upload.status = UploadStatus.completed
+            upload.row_count = row_count
+            db.commit()
+        except Exception as exc:
+            upload.status = UploadStatus.failed
+            upload.error_message = str(exc)
+            db.commit()

--- a/backend/tests/test_dashboard_service.py
+++ b/backend/tests/test_dashboard_service.py
@@ -20,6 +20,10 @@ os.environ.setdefault("SECRET_KEY", "test")
 from backend.app.services.dashboard_service import DashboardService
 from backend.app.schemas.dashboard import DashboardCreate
 from backend.app.models.project import Project
+from backend.app.models.dashboard_topic import DashboardTopic
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from backend.app.database import Base
 
 
 class DummyMetric:
@@ -91,4 +95,17 @@ def test_generate_dashboard_without_projects():
 
     with pytest.raises(ValueError, match="No project metrics found for dashboard generation"):
         asyncio.run(service.generate_dashboard(1, dashboard_data, db))
+
+
+def test_get_topics_seeds_defaults():
+    engine = create_engine("sqlite://")
+    TestingSession = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+    Base.metadata.create_all(bind=engine)
+    db = TestingSession()
+
+    service = DashboardService()
+    topics = asyncio.run(service.get_topics(db))
+
+    assert len(topics) > 0
+    assert db.query(DashboardTopic).count() == len(topics)
 

--- a/backend/tests/test_data_service.py
+++ b/backend/tests/test_data_service.py
@@ -1,6 +1,7 @@
 import pandas as pd
 from io import BytesIO
 import pytest
+import asyncio
 from fastapi import UploadFile
 
 from backend.app.services.data_service import DataService
@@ -8,8 +9,10 @@ from backend.app.models.data_upload import DataUpload
 
 class DummyUpload:
     def __init__(self):
+        self.id = 1
         self.file_name = None
         self.upload_metadata = None
+        self.user_id = 1
 
 class DummyQuery:
     def __init__(self, obj):
@@ -22,6 +25,7 @@ class DummyQuery:
 class DummyDB:
     def __init__(self, upload):
         self.upload = upload
+        self.added = None
     def query(self, model):
         assert model is DataUpload
         return DummyQuery(self.upload)
@@ -29,6 +33,8 @@ class DummyDB:
         pass
     def refresh(self, obj):
         pass
+    def add(self, obj):
+        self.added = obj
 
 def create_excel_upload():
     df1 = pd.DataFrame({'A': [1, 2], 'B': [3, 4]})
@@ -48,34 +54,31 @@ def create_csv_upload(delimiter: str):
     upload = UploadFile(filename='test.csv', file=BytesIO(csv_bytes))
     return upload, df
 
-@pytest.mark.asyncio
-async def test_process_uploaded_file_multi_sheet():
+def test_process_uploaded_file_multi_sheet():
     upload, combined = create_excel_upload()
     dummy_upload = DummyUpload()
     db = DummyDB(dummy_upload)
     service = DataService()
-    result = await service.process_uploaded_file(upload, 1, db)
+    result = asyncio.run(service.process_uploaded_file(upload, 1, db))
 
     assert result['row_count'] == len(combined)
     assert result['processed_data']['row_count'] == len(combined)
     assert result['processed_data']['records'] == combined.to_dict('records')
 
-@pytest.mark.asyncio
-async def test_validate_data_file_multi_sheet():
+def test_validate_data_file_multi_sheet():
     upload, combined = create_excel_upload()
     service = DataService()
-    result = await service.validate_data_file(upload)
+    result = asyncio.run(service.validate_data_file(upload))
     assert result['valid'] is True
     assert result['row_count'] == len(combined)
     assert result['columns'] == list(combined.columns)
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("delimiter", [" ", "\t"])
-async def test_validate_space_or_tab_delimited_csv(delimiter):
+def test_validate_space_or_tab_delimited_csv(delimiter):
     upload, df = create_csv_upload(delimiter)
     service = DataService()
-    result = await service.validate_data_file(upload)
+    result = asyncio.run(service.validate_data_file(upload))
     assert result['valid'] is True
     assert result['columns'] == list(df.columns)
 

--- a/backend/tests/test_ingestion_service.py
+++ b/backend/tests/test_ingestion_service.py
@@ -1,0 +1,73 @@
+import os
+import sys
+import pathlib
+import json
+import asyncio
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
+os.environ.setdefault("DATABASE_URL", "sqlite://")
+os.environ.setdefault("JWT_SECRET", "test")
+os.environ.setdefault("SECRET_KEY", "test")
+os.environ.setdefault("OPENAI_API_KEY", "test")
+os.environ.setdefault("XERO_CLIENT_ID", "test")
+os.environ.setdefault("XERO_CLIENT_SECRET", "test")
+os.environ.setdefault("XERO_REDIRECT_URI", "http://localhost")
+os.environ.setdefault("GOOGLE_CLIENT_ID", "test")
+os.environ.setdefault("GOOGLE_CLIENT_SECRET", "test")
+os.environ.setdefault("GOOGLE_REDIRECT_URI", "http://localhost")
+
+from backend.app.database import Base
+from backend.app.models.data_upload import DataUpload, SourceType, UploadStatus
+from backend.app.models.project import Project
+from backend.app.services.ingestion_service import IngestionService
+
+
+def test_ingest_upload_creates_records(tmp_path):
+    engine = create_engine("sqlite://")
+    TestingSession = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+    Base.metadata.create_all(bind=engine)
+
+    db = TestingSession()
+
+    data = [
+        {
+            "name": "Project A",
+            "activities": [
+                {
+                    "name": "Activity 1",
+                    "outcomes": [
+                        {
+                            "name": "Outcome 1",
+                            "metrics": [{"name": "beneficiaries", "value": 5}]
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+
+    file_path = tmp_path / "upload.json"
+    with open(file_path, "w", encoding="utf-8") as f:
+        json.dump(data, f)
+
+    upload = DataUpload(
+        user_id=1,
+        file_name="upload.json",
+        file_path=str(file_path),
+        source_type=SourceType.manual,
+        status=UploadStatus.pending,
+    )
+    db.add(upload)
+    db.commit()
+    db.refresh(upload)
+
+    service = IngestionService()
+    asyncio.run(service.ingest_upload(upload.id, db))
+    db.refresh(upload)
+
+    assert upload.status == UploadStatus.completed
+    assert db.query(Project).count() == 1

--- a/backend/tests/test_report_service.py
+++ b/backend/tests/test_report_service.py
@@ -1,0 +1,54 @@
+import os
+import sys
+import pathlib
+import asyncio
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
+os.environ.setdefault("DATABASE_URL", "sqlite://")
+os.environ.setdefault("JWT_SECRET", "test")
+os.environ.setdefault("SECRET_KEY", "test")
+os.environ.setdefault("OPENAI_API_KEY", "test")
+os.environ.setdefault("XERO_CLIENT_ID", "test")
+os.environ.setdefault("XERO_CLIENT_SECRET", "test")
+os.environ.setdefault("XERO_REDIRECT_URI", "http://localhost")
+os.environ.setdefault("GOOGLE_CLIENT_ID", "test")
+os.environ.setdefault("GOOGLE_CLIENT_SECRET", "test")
+os.environ.setdefault("GOOGLE_REDIRECT_URI", "http://localhost")
+
+from backend.app.database import Base
+from backend.app.models.project import Project
+from backend.app.models.activity import Activity
+from backend.app.models.outcome import Outcome
+from backend.app.models.metric import Metric
+from backend.app.services.report_service import ReportService
+
+
+def test_generate_report_aggregates_metrics_and_charts():
+    engine = create_engine("sqlite://")
+    TestingSession = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+    Base.metadata.create_all(bind=engine)
+    db = TestingSession()
+
+    project = Project(user_id=1, name="Proj")
+    db.add(project)
+    db.flush()
+    activity = Activity(project_id=project.id, name="Act")
+    db.add(activity)
+    db.flush()
+    outcome = Outcome(activity_id=activity.id, name="Out")
+    db.add(outcome)
+    db.flush()
+    metric = Metric(outcome_id=outcome.id, name="beneficiaries", value=5)
+    db.add(metric)
+    db.commit()
+
+    service = ReportService()
+    report = asyncio.run(service.generate_report(1, "custom", "Title", db))
+    db.refresh(report)
+
+    assert report.metrics["beneficiaries"] == 5
+    assert report.visualizations["impact"][0]["value"] == 5


### PR DESCRIPTION
## Summary
- add ingestion service that reads uploaded files and persists project activity outcome metric data
- save uploaded files locally and launch background ingestion tasks that update upload status and expose file paths
- seed and serve dashboard topics from the database and enhance report generation with aggregated metrics and charts

## Testing
- `pytest backend/tests/test_ingestion_service.py backend/tests/test_report_service.py backend/tests/test_dashboard_service.py backend/tests/test_data_service.py`

------
https://chatgpt.com/codex/tasks/task_e_68a8611b2bd0832bbb5e51046f042faa