### PR TITLE
Adjust upload_data signature

### DIFF
--- a/backend/app/api/routes/data.py
+++ b/backend/app/api/routes/data.py
@@ -16,10 +16,10 @@ router = APIRouter(prefix="/data", tags=["data"])
 
 @router.post("/upload", response_model=DataUploadResponse)
 async def upload_data(
-    file: UploadFile = File(...),
     background_tasks: BackgroundTasks,
+    file: UploadFile = File(...),
     current_user: User = Depends(get_current_user),
-    db: Session = Depends(get_db)
+    db: Session = Depends(get_db),
 ):
     upload_dir = Path("uploads")
     upload_dir.mkdir(exist_ok=True)


### PR DESCRIPTION
## Summary
- ensure BackgroundTasks precedes default params in upload_data route for FastAPI

## Testing
- `uvicorn app.main:app --port 8001 --host 127.0.0.1`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a868afc9a0832b9d5d29ce9bcb4119