### PR TITLE
feat: add ingestion job status tracking

### DIFF
--- a/backend/alembic/versions/0d3e31806d61_create_ingestion_jobs_table.py
+++ b/backend/alembic/versions/0d3e31806d61_create_ingestion_jobs_table.py
@@ -1,0 +1,48 @@
+"""create ingestion jobs table
+
+Revision ID: 0d3e31806d61
+Revises: 7329a50dd3fa
+Create Date: 2024-08-24 00:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "0d3e31806d61"
+down_revision: Union[str, None] = "7329a50dd3fa"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "ingestion_jobs",
+        sa.Column("id", sa.Integer(), primary_key=True, nullable=False),
+        sa.Column("org_id", sa.Integer(), nullable=False),
+        sa.Column("upload_id", sa.Integer(), nullable=False),
+        sa.Column(
+            "status",
+            sa.Enum("queued", "running", "success", "failed", name="ingestionjobstatus"),
+            server_default="queued",
+            nullable=False,
+        ),
+        sa.Column("error_json", sa.JSON(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
+        sa.ForeignKeyConstraint(["upload_id"], ["uploads.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_ingestion_jobs_id"), "ingestion_jobs", ["id"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_ingestion_jobs_id"), table_name="ingestion_jobs")
+    op.drop_table("ingestion_jobs")
+    sa.Enum(name="ingestionjobstatus").drop(op.get_bind())

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -13,6 +13,7 @@ from .api.routes import (
 )
 from .routes.public.template import router as public_template_router
 from .routes.ingest.upload import router as ingest_upload_router
+from .routes.ingest.jobs import router as ingest_jobs_router
 
 app = FastAPI(
     title="ImpactView API",
@@ -39,6 +40,7 @@ app.include_router(reports_router, prefix="/api/v1")
 app.include_router(investors_router, prefix="/api/v1")
 app.include_router(public_template_router)
 app.include_router(ingest_upload_router)
+app.include_router(ingest_jobs_router)
 
 @app.get("/")
 async def root():

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -11,3 +11,4 @@ from .integration import Integration
 from .investor import Investor
 from .audit_log import AuditLog
 from .uploads import Upload
+from .ingestion_jobs import IngestionJob

--- a/backend/app/models/ingestion_jobs.py
+++ b/backend/app/models/ingestion_jobs.py
@@ -1,0 +1,27 @@
+import enum
+from sqlalchemy import Column, Integer, ForeignKey, DateTime, Enum, JSON
+from sqlalchemy.sql import func
+
+from ..database import Base
+
+
+class IngestionJobStatus(str, enum.Enum):
+    queued = "queued"
+    running = "running"
+    success = "success"
+    failed = "failed"
+
+
+class IngestionJob(Base):
+    __tablename__ = "ingestion_jobs"
+
+    id = Column(Integer, primary_key=True, index=True)
+    org_id = Column(Integer, nullable=False)
+    upload_id = Column(Integer, ForeignKey("uploads.id"), nullable=False)
+    status = Column(
+        Enum(IngestionJobStatus, name="ingestionjobstatus"),
+        default=IngestionJobStatus.queued,
+        nullable=False,
+    )
+    error_json = Column(JSON, nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())

--- a/backend/app/routes/ingest/jobs.py
+++ b/backend/app/routes/ingest/jobs.py
@@ -1,0 +1,72 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials
+from sqlalchemy.orm import Session
+from pydantic import BaseModel
+
+from ...api.deps import get_current_user, verify_token, security
+from ...database import get_db
+from ...models.user import User
+from ...models.uploads import Upload
+from ...models.ingestion_jobs import IngestionJob, IngestionJobStatus
+
+router = APIRouter(prefix="/ingest", tags=["ingest"])
+
+
+class JobCreateRequest(BaseModel):
+    upload_id: int
+
+
+class JobStatusResponse(BaseModel):
+    status: IngestionJobStatus
+    error: dict | None = None
+
+
+@router.post("/jobs", status_code=202)
+def create_job(
+    data: JobCreateRequest,
+    current_user: User = Depends(get_current_user),
+    creds: HTTPAuthorizationCredentials = Depends(security),
+    db: Session = Depends(get_db),
+):
+    payload = verify_token(creds.credentials)
+    org_id = payload.get("org_id") if payload else None
+    if org_id is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
+
+    upload = (
+        db.query(Upload)
+        .filter(Upload.id == data.upload_id, Upload.org_id == org_id)
+        .first()
+    )
+    if upload is None:
+        raise HTTPException(status_code=404, detail="Upload not found")
+
+    job = IngestionJob(org_id=org_id, upload_id=upload.id, status=IngestionJobStatus.queued)
+    db.add(job)
+    db.commit()
+    db.refresh(job)
+
+    return {"job_id": job.id}
+
+
+@router.get("/jobs/{job_id}", response_model=JobStatusResponse)
+def get_job(
+    job_id: int,
+    current_user: User = Depends(get_current_user),
+    creds: HTTPAuthorizationCredentials = Depends(security),
+    db: Session = Depends(get_db),
+):
+    payload = verify_token(creds.credentials)
+    org_id = payload.get("org_id") if payload else None
+    if org_id is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
+
+    job = (
+        db.query(IngestionJob)
+        .filter(IngestionJob.id == job_id, IngestionJob.org_id == org_id)
+        .first()
+    )
+    if job is None:
+        raise HTTPException(status_code=404, detail="Job not found")
+
+    return JobStatusResponse(status=job.status, error=job.error_json)

--- a/backend/app/tests/test_ingestion_jobs_status.py
+++ b/backend/app/tests/test_ingestion_jobs_status.py
@@ -1,0 +1,140 @@
+from pathlib import Path
+from fastapi.testclient import TestClient
+from jose import jwt
+import os
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[3]))
+
+# Required environment variables
+os.environ["database_url"] = "sqlite:///./test.db"
+os.environ.setdefault("jwt_secret", "test")
+os.environ.setdefault("openai_api_key", "test")
+os.environ.setdefault("xero_client_id", "test")
+os.environ.setdefault("xero_client_secret", "test")
+os.environ.setdefault("xero_redirect_uri", "http://localhost")
+os.environ.setdefault("google_client_id", "test")
+os.environ.setdefault("google_client_secret", "test")
+os.environ.setdefault("google_redirect_uri", "http://localhost")
+os.environ.setdefault("secret_key", "test")
+
+# Storage configuration
+os.environ.setdefault("STORAGE_PROVIDER", "s3")
+os.environ.setdefault("S3_BUCKET", "test-bucket")
+os.environ.setdefault("S3_REGION", "us-east-1")
+os.environ.setdefault("S3_UPLOAD_PREFIX", "raw/")
+os.environ.setdefault("MAX_UPLOAD_MB", "25")
+os.environ.setdefault("AWS_ACCESS_KEY_ID", "test")
+os.environ.setdefault("AWS_SECRET_ACCESS_KEY", "test")
+
+from backend.app.main import app
+from backend.app.database import Base, engine, SessionLocal
+from backend.app.models.user import User
+from backend.app.models.uploads import Upload, UploadStatus
+from backend.app.models.ingestion_jobs import IngestionJob, IngestionJobStatus
+from backend.app.api import deps as deps_module
+from backend.app.routes.ingest import jobs as jobs_route
+
+# Reset database
+db_path = Path("test.db")
+if db_path.exists():
+    db_path.unlink()
+
+Base.metadata.create_all(bind=engine)
+
+# Seed user and upload
+_db = SessionLocal()
+user = User(id=2, email="user2@example.com", hashed_password="x", name="Test2")
+upload = Upload(
+    org_id=123,
+    user_id=2,
+    filename="data.csv",
+    mime_type="text/csv",
+    size=100,
+    object_key="obj",
+    status=UploadStatus.completed,
+)
+_db.add_all([user, upload])
+_db.commit()
+_db.close()
+
+
+def _fake_verify_token(token: str):
+    try:
+        return jwt.decode(token, os.environ["jwt_secret"], algorithms=["HS256"])
+    except Exception:
+        return None
+
+
+deps_module.verify_token = _fake_verify_token
+jobs_route.verify_token = _fake_verify_token
+
+client = TestClient(app)
+
+
+def make_token(org_id=123):
+    payload = {"sub": "2", "type": "access", "org_id": org_id}
+    return jwt.encode(payload, os.environ["jwt_secret"], algorithm="HS256")
+
+
+def test_create_and_get_job():
+    token = make_token()
+    response = client.post(
+        "/ingest/jobs",
+        json={"upload_id": 1},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert response.status_code == 202
+    job_id = response.json()["job_id"]
+
+    db = SessionLocal()
+    job = db.query(IngestionJob).filter(IngestionJob.id == job_id).first()
+    assert job is not None
+    assert job.status == IngestionJobStatus.queued
+    assert job.org_id == 123
+    db.close()
+
+    response = client.get(
+        f"/ingest/jobs/{job_id}", headers={"Authorization": f"Bearer {token}"}
+    )
+    assert response.status_code == 200
+    assert response.json() == {"status": "queued", "error": None}
+
+
+def test_org_scoped_visibility():
+    token1 = make_token(org_id=123)
+    token2 = make_token(org_id=999)
+    response = client.post(
+        "/ingest/jobs",
+        json={"upload_id": 1},
+        headers={"Authorization": f"Bearer {token1}"},
+    )
+    job_id = response.json()["job_id"]
+
+    response = client.get(
+        f"/ingest/jobs/{job_id}", headers={"Authorization": f"Bearer {token2}"}
+    )
+    assert response.status_code == 404
+
+
+def test_status_and_error_returned():
+    token = make_token()
+    response = client.post(
+        "/ingest/jobs",
+        json={"upload_id": 1},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    job_id = response.json()["job_id"]
+
+    db = SessionLocal()
+    job = db.query(IngestionJob).filter(IngestionJob.id == job_id).first()
+    job.status = IngestionJobStatus.failed
+    job.error_json = {"row": 1, "msg": "bad"}
+    db.commit()
+    db.close()
+
+    response = client.get(
+        f"/ingest/jobs/{job_id}", headers={"Authorization": f"Bearer {token}"}
+    )
+    assert response.status_code == 200
+    assert response.json() == {"status": "failed", "error": {"row": 1, "msg": "bad"}}


### PR DESCRIPTION
## Summary
- track ingestion jobs with status and error JSON
- expose `/ingest/jobs` endpoints to create jobs and fetch status
- cover org-scoped job visibility with tests

## Testing
- `pytest backend/app/tests/test_upload_signed_url.py -q`
- `pytest backend/app/tests/test_template_download.py -q`
- `pytest backend/app/tests/test_ingestion_jobs_status.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac2c835e6c832ba4a89c8b0c207b92