### PR TITLE
Bootstrap Celery worker with Redis and logging

### DIFF
--- a/backend/app/observability/events.py
+++ b/backend/app/observability/events.py
@@ -1,0 +1,15 @@
+import logging
+from typing import Any, Optional
+
+logger = logging.getLogger("observability")
+
+
+def log_event(
+    event: str,
+    org_id: Optional[str] = None,
+    project_id: Optional[str] = None,
+    **payload: Any,
+) -> None:
+    """Log an observability event with context."""
+    context = {"org": org_id, "project": project_id, **payload}
+    logger.info("%s %s", event, context)

--- a/backend/app/tests/test_worker_boots.py
+++ b/backend/app/tests/test_worker_boots.py
@@ -1,0 +1,24 @@
+import os
+import subprocess
+import time
+
+import pytest
+from celery.contrib.testing.worker import start_worker
+
+
+@pytest.fixture(scope="module")
+def redis_server():
+    proc = subprocess.Popen(["redis-server", "--save", "", "--appendonly", "no"])
+    time.sleep(0.5)
+    yield proc
+    proc.terminate()
+    proc.wait()
+
+
+def test_worker_boots(redis_server, monkeypatch):
+    monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
+    from backend.worker.worker import app, ping
+
+    with start_worker(app, concurrency=1):
+        result = ping.delay()
+        assert result.get(timeout=10) == "pong"

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -18,6 +18,12 @@ services:
       retries: 15
     restart: unless-stopped
 
+  redis:
+    image: redis:7
+    ports:
+      - "6379:6379"
+    restart: unless-stopped
+
   backend:
     build:
       context: .
@@ -43,6 +49,23 @@ services:
       db:
         condition: service_healthy
     restart: unless-stopped
+
+  worker:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    command: celery -A worker.worker worker --loglevel=info --concurrency=${WORKER_CONCURRENCY:-2}
+    volumes:
+      - .:/app
+    env_file:
+      - .env            # ← make sure this points to your real .env
+    environment:
+      REDIS_URL: ${REDIS_URL:-redis://redis:6379/0}
+      WORKER_CONCURRENCY: ${WORKER_CONCURRENCY:-2}
+      PYTHONUNBUFFERED: "1"
+    depends_on:
+      redis:
+        condition: service_started
 
 volumes:
   postgres_data:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -22,3 +22,5 @@ pydantic-settings==2.1.0
 pydantic[email]
 reportlab==3.6.12
 boto3==1.34.146
+celery[redis]==5.3.6
+redis==5.0.1

--- a/backend/worker/worker.py
+++ b/backend/worker/worker.py
@@ -1,0 +1,49 @@
+import os
+from celery import Celery
+from celery.signals import worker_ready, worker_shutdown
+
+from app.observability.events import log_event
+
+REDIS_URL = os.environ.get("REDIS_URL", "redis://localhost:6379/0")
+WORKER_CONCURRENCY = int(os.environ.get("WORKER_CONCURRENCY", "2"))
+
+app = Celery(
+    "worker",
+    broker=REDIS_URL,
+    backend=REDIS_URL,
+)
+
+app.conf.update(
+    task_serializer="json",
+    accept_content=["json"],
+    result_serializer="json",
+    worker_concurrency=WORKER_CONCURRENCY,
+    task_default_queue="ingest",
+)
+
+class BaseTask(app.Task):
+    """Task base class with automatic retries and backoff."""
+
+    autoretry_for = (Exception,)
+    retry_backoff = True
+    retry_jitter = True
+
+
+@app.task(bind=True, base=BaseTask)
+def ping(self):
+    """Simple task used for worker heartbeats in tests."""
+    return "pong"
+
+
+ORG_ID = os.getenv("ORG_ID")
+PROJECT_ID = os.getenv("PROJECT_ID")
+
+
+@worker_ready.connect
+def _on_worker_ready(**_):
+    log_event("worker_ready", org_id=ORG_ID, project_id=PROJECT_ID)
+
+
+@worker_shutdown.connect
+def _on_worker_shutdown(**_):
+    log_event("worker_shutdown", org_id=ORG_ID, project_id=PROJECT_ID)


### PR DESCRIPTION
## Summary
- add Celery worker wired to Redis with retry/backoff and single `ingest` queue
- log worker lifecycle events with org/project context
- provide docker compose services for Redis and the worker
- add test verifying worker boots

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'celery')*


------
https://chatgpt.com/codex/tasks/task_e_68ac2f19fb88832ba8410793f7a63e92