### PR TITLE
feat: add staging tables and parser

### DIFF
--- a/backend/alembic/versions/b517939f71cb_create_staging_tables.py
+++ b/backend/alembic/versions/b517939f71cb_create_staging_tables.py
@@ -1,0 +1,48 @@
+"""create staging tables"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = 'b517939f71cb'
+down_revision = '3c280994c450'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    common = [
+        sa.Column("id", sa.String(), primary_key=True),
+        sa.Column("upload_id", sa.String(), nullable=False),
+        sa.Column("row_num", sa.Integer(), nullable=False),
+        sa.Column("raw_json", sa.JSON(), nullable=False),
+        sa.Column("parse_errors", sa.JSON(), nullable=True),
+        sa.Column("source_system", sa.String(), nullable=False, server_default="excel"),
+        sa.Column("external_id", sa.String(), nullable=True),
+        sa.Column(
+            "ingested_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("NOW()"),
+        ),
+        sa.Column("row_hash", sa.String(), nullable=True),
+        sa.Column("import_batch_id", sa.String(), sa.ForeignKey("import_batches.id")),
+        sa.Column("schema_version", sa.Integer(), nullable=False, server_default="1"),
+    ]
+    for table in [
+        "stg_project_info",
+        "stg_activities",
+        "stg_outcomes",
+        "stg_funding_resources",
+        "stg_beneficiaries",
+    ]:
+        op.create_table(table, *common)
+
+
+def downgrade() -> None:
+    for table in [
+        "stg_project_info",
+        "stg_activities",
+        "stg_outcomes",
+        "stg_funding_resources",
+        "stg_beneficiaries",
+    ]:
+        op.drop_table(table)

--- a/backend/app/ingest/hash.py
+++ b/backend/app/ingest/hash.py
@@ -1,0 +1,16 @@
+import hashlib
+import json
+import math
+from typing import Any, Dict
+
+
+def canonical_row_hash(row: Dict[str, Any]) -> str:
+    """Return a stable hash for a row of data."""
+    cleaned: Dict[str, Any] = {}
+    for key, value in row.items():
+        if isinstance(value, float) and math.isnan(value):
+            cleaned[key] = None
+        else:
+            cleaned[key] = value
+    encoded = json.dumps(cleaned, sort_keys=True, default=str)
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()

--- a/backend/app/ingest/parse_and_stage.py
+++ b/backend/app/ingest/parse_and_stage.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+from typing import Dict, Any
+
+import pandas as pd
+import sqlalchemy as sa
+
+from ..database import SessionLocal, engine
+from .validators import (
+    REQUIRED_SHEETS,
+    validate_excel_schema,
+    validate_csv_schema,
+)
+from .hash import canonical_row_hash
+
+SHEET_TABLE_MAP = {
+    "Project Info": "stg_project_info",
+    "Activities": "stg_activities",
+    "Outcomes": "stg_outcomes",
+    "Funding & Resources": "stg_funding_resources",
+    "Beneficiaries": "stg_beneficiaries",
+}
+
+SHEET_KEY_MAP = {
+    "Project Info": "project_info",
+    "Activities": "activities",
+    "Outcomes": "outcomes",
+    "Funding & Resources": "funding_resources",
+    "Beneficiaries": "beneficiaries",
+}
+
+FILE_SHEET_MAP = {
+    "project_info": "Project Info",
+    "activities": "Activities",
+    "outcomes": "Outcomes",
+    "funding_resources": "Funding & Resources",
+    "beneficiaries": "Beneficiaries",
+}
+
+
+def _read_workbook(path: Path) -> Dict[str, pd.DataFrame]:
+    if path.suffix.lower() == ".csv":
+        sheet = FILE_SHEET_MAP.get(path.stem.lower())
+        if sheet is None:
+            raise ValueError("Unrecognised CSV filename")
+        df = pd.read_csv(path)
+        return {sheet: df}
+    else:
+        return pd.read_excel(path, sheet_name=None)
+
+
+def parse_and_stage(
+    *,
+    upload_id: str,
+    import_batch_id: str,
+    file_path: str,
+    source_system: str = "excel",
+) -> Dict[str, int]:
+    path = Path(file_path)
+    content = path.read_bytes()
+    if path.suffix.lower() == ".csv":
+        sheet = FILE_SHEET_MAP.get(path.stem.lower())
+        if sheet is None:
+            raise ValueError("Unrecognised CSV filename")
+        validate_csv_schema(content, sheet)
+    else:
+        validate_excel_schema(content)
+
+    dfs = _read_workbook(path)
+    metadata = sa.MetaData()
+    counts = {key: 0 for key in SHEET_KEY_MAP.values()}
+
+    db = SessionLocal()
+    try:
+        for sheet_name, df in dfs.items():
+            table_name = SHEET_TABLE_MAP.get(sheet_name)
+            key = SHEET_KEY_MAP.get(sheet_name)
+            if table_name is None or key is None:
+                continue
+            table = sa.Table(table_name, metadata, autoload_with=engine)
+            required_cols = REQUIRED_SHEETS[sheet_name]
+            for idx, row in df.iterrows():
+                raw: Dict[str, Any] = {
+                    col: (None if pd.isna(val) else val) for col, val in row.items()
+                }
+                missing = [c for c in required_cols if pd.isna(row.get(c))]
+                parse_errors = {"missing": missing} if missing else None
+                stmt = table.insert().values(
+                    id=str(uuid.uuid4()),
+                    upload_id=upload_id,
+                    row_num=int(idx) + 1,
+                    raw_json=raw,
+                    parse_errors=parse_errors,
+                    source_system=source_system,
+                    external_id=None,
+                    row_hash=canonical_row_hash(raw),
+                    import_batch_id=import_batch_id,
+                )
+                db.execute(stmt)
+                counts[key] += 1
+        db.commit()
+    finally:
+        db.close()
+
+    return counts

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -13,3 +13,10 @@ from .audit_log import AuditLog
 from .uploads import Upload
 from .ingestion_jobs import IngestionJob
 from .import_batches import ImportBatch
+from .staging import (
+    StgProjectInfo,
+    StgActivity,
+    StgOutcome,
+    StgFundingResource,
+    StgBeneficiary,
+)

--- a/backend/app/models/staging.py
+++ b/backend/app/models/staging.py
@@ -1,0 +1,40 @@
+from sqlalchemy import Column, Integer, String, JSON, DateTime, ForeignKey
+from sqlalchemy.sql import func
+
+from ..database import Base
+
+
+class _StagingBase(Base):
+    __abstract__ = True
+
+    id = Column(String, primary_key=True)
+    upload_id = Column(String, nullable=False)
+    row_num = Column(Integer, nullable=False)
+    raw_json = Column(JSON, nullable=False)
+    parse_errors = Column(JSON, nullable=True)
+    source_system = Column(String, nullable=False, server_default="excel")
+    external_id = Column(String, nullable=True)
+    ingested_at = Column(DateTime(timezone=True), server_default=func.now())
+    row_hash = Column(String, nullable=True)
+    import_batch_id = Column(String, ForeignKey("import_batches.id"))
+    schema_version = Column(Integer, nullable=False, server_default="1")
+
+
+class StgProjectInfo(_StagingBase):
+    __tablename__ = "stg_project_info"
+
+
+class StgActivity(_StagingBase):
+    __tablename__ = "stg_activities"
+
+
+class StgOutcome(_StagingBase):
+    __tablename__ = "stg_outcomes"
+
+
+class StgFundingResource(_StagingBase):
+    __tablename__ = "stg_funding_resources"
+
+
+class StgBeneficiary(_StagingBase):
+    __tablename__ = "stg_beneficiaries"

--- a/backend/app/tests/test_parse_and_stage.py
+++ b/backend/app/tests/test_parse_and_stage.py
@@ -1,0 +1,114 @@
+from pathlib import Path
+import os
+import sys
+import uuid
+
+import pandas as pd
+import pytest
+
+# Setup environment and path
+sys.path.append(str(Path(__file__).resolve().parents[3]))
+os.environ["database_url"] = "sqlite:///./test.db"
+_db_path = Path("test.db")
+if _db_path.exists():
+    _db_path.unlink()
+os.environ.setdefault("jwt_secret", "test")
+os.environ.setdefault("openai_api_key", "test")
+os.environ.setdefault("xero_client_id", "test")
+os.environ.setdefault("xero_client_secret", "test")
+os.environ.setdefault("xero_redirect_uri", "http://localhost")
+os.environ.setdefault("google_client_id", "test")
+os.environ.setdefault("google_client_secret", "test")
+os.environ.setdefault("google_redirect_uri", "http://localhost")
+os.environ.setdefault("secret_key", "test")
+
+from backend.app.database import Base, engine, SessionLocal
+from backend.app.ingest.validators import REQUIRED_SHEETS
+from backend.app.ingest.parse_and_stage import parse_and_stage
+from backend.app.ingest.errors import SchemaValidationError
+from backend.app.models.staging import (
+    StgProjectInfo,
+    StgActivity,
+    StgOutcome,
+    StgFundingResource,
+    StgBeneficiary,
+)
+
+# Ensure tables exist
+Base.metadata.create_all(bind=engine)
+
+
+def _build_workbook(tmp_path: Path) -> Path:
+    sheets = {}
+    for name, cols in REQUIRED_SHEETS.items():
+        rows = [{c: f"{c} value" for c in cols}]
+        if name == "Project Info":
+            bad = {c: f"{c} value" for c in cols if c != "Project ID"}
+            rows.append(bad)
+        df = pd.DataFrame(rows)
+        sheets[name] = df
+    path = tmp_path / "data.xlsx"
+    with pd.ExcelWriter(path) as writer:
+        for name, df in sheets.items():
+            df.to_excel(writer, sheet_name=name, index=False)
+    return path
+
+
+def test_parse_and_stage_excel(tmp_path):
+    path = _build_workbook(tmp_path)
+    counts = parse_and_stage(
+        upload_id=str(uuid.uuid4()),
+        import_batch_id=str(uuid.uuid4()),
+        file_path=str(path),
+    )
+    assert counts == {
+        "project_info": 2,
+        "activities": 1,
+        "outcomes": 1,
+        "funding_resources": 1,
+        "beneficiaries": 1,
+    }
+    db = SessionLocal()
+    row = (
+        db.query(StgProjectInfo)
+        .filter(StgProjectInfo.row_num == 2)
+        .one()
+    )
+    assert row.parse_errors == {"missing": ["Project ID"]}
+    db.close()
+
+
+def test_parse_and_stage_csv(tmp_path):
+    cols = REQUIRED_SHEETS["Project Info"]
+    df = pd.DataFrame([{c: "val" for c in cols}])
+    path = tmp_path / "project_info.csv"
+    df.to_csv(path, index=False)
+    counts = parse_and_stage(
+        upload_id=str(uuid.uuid4()),
+        import_batch_id=str(uuid.uuid4()),
+        file_path=str(path),
+    )
+    assert counts["project_info"] == 1
+    db = SessionLocal()
+    assert db.query(StgProjectInfo).count() >= 1
+    db.close()
+
+
+def test_parse_and_stage_schema_error(tmp_path):
+    sheets = {}
+    for name, cols in REQUIRED_SHEETS.items():
+        if name == "Activities":
+            df = pd.DataFrame(columns=[c for c in cols if c != "Activity Name"])
+        else:
+            df = pd.DataFrame(columns=cols)
+        sheets[name] = df
+    path = tmp_path / "bad.xlsx"
+    with pd.ExcelWriter(path) as writer:
+        for name, df in sheets.items():
+            df.to_excel(writer, sheet_name=name, index=False)
+    with pytest.raises(SchemaValidationError):
+        parse_and_stage(
+            upload_id=str(uuid.uuid4()),
+            import_batch_id=str(uuid.uuid4()),
+            file_path=str(path),
+        )


### PR DESCRIPTION
## Summary
- create staging tables and models for project info, activities, outcomes, funding resources and beneficiaries
- implement `parse_and_stage` to validate uploads, hash canonical rows and record per-row errors
- cover staging logic with tests for excel/csv and schema validation

## Testing
- `pytest backend/app/tests/test_parse_and_stage.py::test_parse_and_stage_excel -q`
- `pytest backend/app/tests/test_parse_and_stage.py::test_parse_and_stage_csv -q`
- `pytest backend/app/tests/test_parse_and_stage.py::test_parse_and_stage_schema_error -q`
- `pytest -q` *(fails: UNIQUE constraint failed: users.id; attempt to write a readonly database)*

------
https://chatgpt.com/codex/tasks/task_e_68ac38d24a60832bb0edfdd3e606cb45