### PR TITLE
Add Excel field mapping config and loader

### DIFF
--- a/backend/app/ingest/mapping_loader.py
+++ b/backend/app/ingest/mapping_loader.py
@@ -1,0 +1,40 @@
+import yaml
+from pathlib import Path
+from typing import Dict
+
+
+def load_mapping(source_system: str = "excel", version: int = 1) -> Dict[str, Dict[str, str]]:
+    """Load field mapping configuration.
+
+    Parameters
+    ----------
+    source_system: str
+        Source system identifier (e.g., "excel").
+    version: int
+        Mapping version number.
+
+    Returns
+    -------
+    dict
+        Nested dictionary mapping sheet names to field mappings where
+        each field mapping maps normalized source column names to
+        universal schema names.
+    """
+    mappings_dir = Path(__file__).with_name("mappings")
+    path = mappings_dir / f"{source_system}_v{version}.yml"
+    with path.open("r", encoding="utf-8") as f:
+        raw = yaml.safe_load(f) or {}
+
+    result: Dict[str, Dict[str, str]] = {}
+    for sheet_name, fields in raw.items():
+        normalized_sheet = sheet_name.strip().lower()
+        result[normalized_sheet] = {}
+        if not isinstance(fields, dict):
+            continue
+        for target, source in fields.items():
+            if source is None:
+                continue
+            normalized_source = str(source).strip().lower()
+            normalized_target = str(target).strip().lower()
+            result[normalized_sheet][normalized_source] = normalized_target
+    return result

--- a/backend/app/ingest/mappings/excel_v1.yml
+++ b/backend/app/ingest/mappings/excel_v1.yml
@@ -1,0 +1,47 @@
+project_info:
+  project_id: "Project ID"
+  name: "Project Name"
+  org_name: "Org Name"
+  start_date: "Start Date"
+  end_date: "End Date"
+  country: "Country"
+  region: "Region"
+  sdg_goal: "SDG Goal"
+  notes: "Notes"
+
+activities:
+  project_id: "Project ID"
+  date: "Date"
+  activity_type: "Activity Type"
+  activity_name: "Activity Name"
+  beneficiaries_reached: "Beneficiaries Reached"
+  location: "Location"
+  notes: "Notes"
+
+outcomes:
+  project_id: "Project ID"
+  date: "Date"
+  outcome_metric: "Outcome Metric"
+  value: "Value"
+  unit: "Unit"
+  method: "Method of Measurement"
+  notes: "Notes"
+
+funding_resources:
+  project_id: "Project ID"
+  date: "Date"
+  funding_source: "Funding Source"
+  received: "Funding Received"
+  spent: "Funding Spent"
+  volunteer_hours: "Volunteer Hours"
+  staff_hours: "Staff Hours"
+  notes: "Notes"
+
+beneficiaries:
+  project_id: "Project ID"
+  date: "Date"
+  group: "Beneficiary Group"
+  count: "Count"
+  demographic_info: "Demographic Info"
+  location: "Location"
+  notes: "Notes"

--- a/backend/app/tests/test_mapping_loader.py
+++ b/backend/app/tests/test_mapping_loader.py
@@ -1,0 +1,62 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[3]))
+
+from backend.app.ingest.mapping_loader import load_mapping
+
+EXPECTED_MAPPING = {
+    "project_info": {
+        "project id": "project_id",
+        "project name": "name",
+        "org name": "org_name",
+        "start date": "start_date",
+        "end date": "end_date",
+        "country": "country",
+        "region": "region",
+        "sdg goal": "sdg_goal",
+        "notes": "notes",
+    },
+    "activities": {
+        "project id": "project_id",
+        "date": "date",
+        "activity type": "activity_type",
+        "activity name": "activity_name",
+        "beneficiaries reached": "beneficiaries_reached",
+        "location": "location",
+        "notes": "notes",
+    },
+    "outcomes": {
+        "project id": "project_id",
+        "date": "date",
+        "outcome metric": "outcome_metric",
+        "value": "value",
+        "unit": "unit",
+        "method of measurement": "method",
+        "notes": "notes",
+    },
+    "funding_resources": {
+        "project id": "project_id",
+        "date": "date",
+        "funding source": "funding_source",
+        "funding received": "received",
+        "funding spent": "spent",
+        "volunteer hours": "volunteer_hours",
+        "staff hours": "staff_hours",
+        "notes": "notes",
+    },
+    "beneficiaries": {
+        "project id": "project_id",
+        "date": "date",
+        "beneficiary group": "group",
+        "count": "count",
+        "demographic info": "demographic_info",
+        "location": "location",
+        "notes": "notes",
+    },
+}
+
+
+def test_load_mapping_excel_v1():
+    mapping = load_mapping()
+    assert mapping == EXPECTED_MAPPING


### PR DESCRIPTION
## Summary
- add config-driven loader for source field mappings
- define Excel v1 mapping to universal schema
- test that mappings load and normalize correctly

## Testing
- `pytest backend/app/tests/test_mapping_loader.py -q`
- `pytest backend/app/tests -q` *(fails: UNIQUE constraint failed, attempt to write a readonly database)*

------
https://chatgpt.com/codex/tasks/task_e_68ac3b150ca8832ba225874231611ba0