### PR TITLE
Add data row normalization utilities and tests

### DIFF
--- a/backend/app/ingest/normalize.py
+++ b/backend/app/ingest/normalize.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+from datetime import datetime, date
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+from dateutil.relativedelta import relativedelta
+
+from .mapping_loader import load_mapping
+
+
+DATE_FIELDS = {"date", "start_date", "end_date"}
+NUMERIC_FIELDS = {
+    "beneficiaries_reached",
+    "received",
+    "spent",
+    "value",
+    "volunteer_hours",
+    "staff_hours",
+    "count",
+}
+INT_FIELDS = {"beneficiaries_reached", "count"}
+CATEGORY_FIELDS = {
+    "activity_type",
+    "funding_source",
+    "group",
+    "country",
+    "region",
+    "sdg_goal",
+    "location",
+    "unit",
+    "method",
+}
+
+
+def coerce_date(s: Any) -> Optional[date]:
+    if s in (None, ""):
+        return None
+    s = str(s).strip()
+    # YYYY-MM-DD
+    try:
+        return datetime.strptime(s, "%Y-%m-%d").date()
+    except Exception:
+        pass
+    # YYYY-MM
+    try:
+        d = datetime.strptime(s, "%Y-%m")
+        # last day of month
+        next_month = d.replace(day=28) + relativedelta(days=4)
+        last_day = next_month - relativedelta(days=next_month.day)
+        return last_day.date()
+    except Exception:
+        return None
+
+
+def coerce_number(x: Any) -> Optional[float]:
+    try:
+        if x in (None, ""):
+            return None
+        return float(str(x).replace(",", ""))
+    except Exception:
+        return None
+
+
+def _standardize_category(value: Any) -> Optional[str]:
+    if value in (None, ""):
+        return None
+    return str(value).strip().title()
+
+
+def normalize_row(
+    raw: Dict[str, Any],
+    sheet: str,
+    *,
+    mapping: Optional[Dict[str, Dict[str, str]]] = None,
+) -> Tuple[Dict[str, Any], Optional[Dict[str, List[str]]]]:
+    """Normalize a single raw row.
+
+    Parameters
+    ----------
+    raw: Dict[str, Any]
+        Raw row with original column names.
+    sheet: str
+        Sheet name (e.g., "activities").
+    mapping: Optional[Dict[str, Dict[str, str]]]
+        Pre-loaded mapping. If not provided it will be loaded for the default
+        source system.
+
+    Returns
+    -------
+    Tuple[Dict[str, Any], Optional[Dict[str, List[str]]]]
+        Normalized values dictionary and parse error information.
+    """
+
+    if mapping is None:
+        mapping = load_mapping()
+    sheet_map = mapping.get(sheet.strip().lower(), {})
+
+    normalized: Dict[str, Any] = {}
+    invalid_fields: List[str] = []
+
+    for src_key, value in raw.items():
+        norm_key = sheet_map.get(str(src_key).strip().lower())
+        if norm_key is None:
+            continue
+        if value in (None, ""):
+            normalized[norm_key] = None
+            continue
+        if norm_key in DATE_FIELDS:
+            coerced = coerce_date(value)
+            if coerced is None:
+                invalid_fields.append(norm_key)
+            normalized[norm_key] = coerced
+        elif norm_key in NUMERIC_FIELDS:
+            num = coerce_number(value)
+            if num is None:
+                invalid_fields.append(norm_key)
+            else:
+                if norm_key in INT_FIELDS:
+                    num = int(num)
+            normalized[norm_key] = num
+        elif norm_key in CATEGORY_FIELDS:
+            normalized[norm_key] = _standardize_category(value)
+        else:
+            normalized[norm_key] = value
+
+    parse_errors = {"invalid": invalid_fields} if invalid_fields else None
+    return normalized, parse_errors
+
+
+def normalize_rows(
+    rows: Iterable[Dict[str, Any]],
+    sheet: str,
+    *,
+    mapping: Optional[Dict[str, Dict[str, str]]] = None,
+) -> List[Tuple[Dict[str, Any], Optional[Dict[str, List[str]]]]]:
+    """Normalize multiple rows for a given sheet."""
+
+    results: List[Tuple[Dict[str, Any], Optional[Dict[str, List[str]]]]] = []
+    for row in rows:
+        results.append(normalize_row(row, sheet, mapping=mapping))
+    return results
+

--- a/backend/app/tests/test_normalization.py
+++ b/backend/app/tests/test_normalization.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+import sys
+
+import pandas as pd
+
+# Add repository root to path
+sys.path.append(str(Path(__file__).resolve().parents[3]))
+
+from backend.app.ingest.normalize import normalize_row
+from backend.app.ingest.mapping_loader import load_mapping
+
+
+def test_normalize_sample_valid():
+    root = Path(__file__).resolve().parents[3]
+    mapping = load_mapping()
+
+    xls = pd.ExcelFile(root / "fixtures" / "sample_valid.xlsx")
+
+    activities = pd.read_excel(xls, "Activities")
+    row = activities.iloc[0].to_dict()
+    row["Activity Type"] = "workshop"  # ensure category normalization
+    norm, errors = normalize_row(row, "activities", mapping=mapping)
+    assert errors is None
+    assert norm["activity_type"] == "Workshop"
+    assert norm["beneficiaries_reached"] == 30
+    assert norm["date"].isoformat() == "2025-06-01"
+
+    beneficiaries = pd.read_excel(xls, "Beneficiaries")
+    row = beneficiaries.iloc[0].to_dict()
+    norm, errors = normalize_row(row, "beneficiaries", mapping=mapping)
+    assert errors is None
+    assert norm["date"].isoformat() == "2025-06-30"
+
+
+def test_normalize_bad_types():
+    root = Path(__file__).resolve().parents[3]
+    mapping = load_mapping()
+
+    xls = pd.ExcelFile(root / "fixtures" / "bad_types.xlsx")
+
+    activities = pd.read_excel(xls, "Activities")
+    row = activities.iloc[0].to_dict()
+    norm, errors = normalize_row(row, "activities", mapping=mapping)
+    assert errors == {"invalid": ["beneficiaries_reached"]}
+    assert norm["beneficiaries_reached"] is None
+
+    outcomes = pd.read_excel(xls, "Outcomes")
+    row = outcomes.iloc[0].to_dict()
+    norm, errors = normalize_row(row, "outcomes", mapping=mapping)
+    assert errors == {"invalid": ["value"]}
+    assert norm["value"] is None


### PR DESCRIPTION
## Summary
- add functions to coerce dates, numbers, and categories for ingest rows
- collect parse errors on invalid types while mapping fields
- cover normal and bad-type cases with tests

## Testing
- `pytest backend/app/tests/test_normalization.py -q`
- `pytest backend/app/tests -q` *(fails: UNIQUE constraint failed / readonly database)*

------
https://chatgpt.com/codex/tasks/task_e_68ac3c68e560832bab198dff5efd5788