### PR TITLE
Implement core tables and loader with idempotent upsert

### DIFF
--- a/backend/alembic/versions/e1b312d4e3b1_create_core_tables.py
+++ b/backend/alembic/versions/e1b312d4e3b1_create_core_tables.py
@@ -1,0 +1,142 @@
+"""create core domain tables"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "e1b312d4e3b1"
+down_revision = "b517939f71cb"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "projects",
+        sa.Column("id", sa.String(), primary_key=True),
+        sa.Column("owner_org_id", sa.String(), nullable=False),
+        sa.Column("project_id", sa.String(), nullable=False),
+        sa.Column("name", sa.String()),
+        sa.Column("org_name", sa.String()),
+        sa.Column("start_date", sa.Date()),
+        sa.Column("end_date", sa.Date()),
+        sa.Column("country", sa.String()),
+        sa.Column("region", sa.String()),
+        sa.Column("sdg_goal", sa.String()),
+        sa.Column("notes", sa.Text()),
+        sa.Column("source_system", sa.String(), nullable=False, server_default="excel"),
+        sa.Column("external_id", sa.String()),
+        sa.Column(
+            "ingested_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("NOW()"),
+        ),
+        sa.Column("row_hash", sa.String()),
+        sa.Column("import_batch_id", sa.String(), sa.ForeignKey("import_batches.id")),
+        sa.Column("schema_version", sa.Integer(), nullable=False, server_default="1"),
+        sa.UniqueConstraint("owner_org_id", "project_id", name="uq_project_org_pid"),
+    )
+
+    op.create_table(
+        "activities",
+        sa.Column("id", sa.String(), primary_key=True),
+        sa.Column("project_fk", sa.String(), sa.ForeignKey("projects.id"), nullable=False),
+        sa.Column("date", sa.Date()),
+        sa.Column("activity_type", sa.String()),
+        sa.Column("activity_name", sa.String()),
+        sa.Column("beneficiaries_reached", sa.Integer()),
+        sa.Column("location", sa.String()),
+        sa.Column("notes", sa.Text()),
+        sa.Column("source_system", sa.String(), nullable=False, server_default="excel"),
+        sa.Column("external_id", sa.String()),
+        sa.Column(
+            "ingested_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("NOW()"),
+        ),
+        sa.Column("row_hash", sa.String()),
+        sa.Column("import_batch_id", sa.String(), sa.ForeignKey("import_batches.id")),
+        sa.Column("schema_version", sa.Integer(), nullable=False, server_default="1"),
+        sa.UniqueConstraint("project_fk", "activity_name", "date", name="uq_activity_natural"),
+    )
+
+    op.create_table(
+        "outcomes",
+        sa.Column("id", sa.String(), primary_key=True),
+        sa.Column("project_fk", sa.String(), sa.ForeignKey("projects.id"), nullable=False),
+        sa.Column("date", sa.Date()),
+        sa.Column("outcome_metric", sa.String()),
+        sa.Column("value", sa.Float()),
+        sa.Column("unit", sa.String()),
+        sa.Column("method", sa.String()),
+        sa.Column("notes", sa.Text()),
+        sa.Column("source_system", sa.String(), nullable=False, server_default="excel"),
+        sa.Column("external_id", sa.String()),
+        sa.Column(
+            "ingested_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("NOW()"),
+        ),
+        sa.Column("row_hash", sa.String()),
+        sa.Column("import_batch_id", sa.String(), sa.ForeignKey("import_batches.id")),
+        sa.Column("schema_version", sa.Integer(), nullable=False, server_default="1"),
+        sa.UniqueConstraint("project_fk", "outcome_metric", "date", name="uq_outcome_natural"),
+    )
+
+    op.create_table(
+        "funding_resources",
+        sa.Column("id", sa.String(), primary_key=True),
+        sa.Column("project_fk", sa.String(), sa.ForeignKey("projects.id"), nullable=False),
+        sa.Column("date", sa.Date()),
+        sa.Column("funding_source", sa.String()),
+        sa.Column("received", sa.Float()),
+        sa.Column("spent", sa.Float()),
+        sa.Column("volunteer_hours", sa.Float()),
+        sa.Column("staff_hours", sa.Float()),
+        sa.Column("notes", sa.Text()),
+        sa.Column("source_system", sa.String(), nullable=False, server_default="excel"),
+        sa.Column("external_id", sa.String()),
+        sa.Column(
+            "ingested_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("NOW()"),
+        ),
+        sa.Column("row_hash", sa.String()),
+        sa.Column("import_batch_id", sa.String(), sa.ForeignKey("import_batches.id")),
+        sa.Column("schema_version", sa.Integer(), nullable=False, server_default="1"),
+        sa.UniqueConstraint(
+            "project_fk", "funding_source", "date", name="uq_funding_natural"
+        ),
+    )
+
+    op.create_table(
+        "beneficiaries",
+        sa.Column("id", sa.String(), primary_key=True),
+        sa.Column("project_fk", sa.String(), sa.ForeignKey("projects.id"), nullable=False),
+        sa.Column("date", sa.Date()),
+        sa.Column("group", sa.String()),
+        sa.Column("count", sa.Integer()),
+        sa.Column("demographic_info", sa.String()),
+        sa.Column("location", sa.String()),
+        sa.Column("notes", sa.Text()),
+        sa.Column("source_system", sa.String(), nullable=False, server_default="excel"),
+        sa.Column("external_id", sa.String()),
+        sa.Column(
+            "ingested_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("NOW()"),
+        ),
+        sa.Column("row_hash", sa.String()),
+        sa.Column("import_batch_id", sa.String(), sa.ForeignKey("import_batches.id")),
+        sa.Column("schema_version", sa.Integer(), nullable=False, server_default="1"),
+        sa.UniqueConstraint("project_fk", "group", "date", name="uq_beneficiary_natural"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("beneficiaries")
+    op.drop_table("funding_resources")
+    op.drop_table("outcomes")
+    op.drop_table("activities")
+    op.drop_table("projects")
+

--- a/backend/app/ingest/load_to_core.py
+++ b/backend/app/ingest/load_to_core.py
@@ -1,0 +1,387 @@
+from __future__ import annotations
+
+import uuid
+from datetime import date
+
+from sqlalchemy.orm import Session
+from sqlalchemy import text
+
+from ..database import SessionLocal
+from ..models import (
+    Project,
+    Activity,
+    Outcome,
+    FundingResource,
+    Beneficiary,
+    StgProjectInfo,
+    StgActivity,
+    StgOutcome,
+    StgFundingResource,
+    StgBeneficiary,
+)
+
+
+def _parse_date(val: str | None) -> date | None:
+    if not val:
+        return None
+    return date.fromisoformat(val)
+
+
+def _parse_int(val):
+    if val is None or val == "":
+        return None
+    return int(val)
+
+
+def _parse_float(val):
+    if val is None or val == "":
+        return None
+    return float(val)
+
+
+def load_to_core(import_batch_id: str) -> dict:
+    """Load normalized data from staging tables into core tables.
+
+    The function performs idempotent upserts based on natural keys or the
+    stored row hash.  When the same data is ingested multiple times it
+    results in no changes to the core tables.
+    """
+
+    session: Session = SessionLocal()
+    # Ensure SQLite enforces foreign key constraints
+    session.execute(text("PRAGMA foreign_keys=ON"))
+    counts = {
+        "projects": {"inserted": 0, "updated": 0},
+        "activities": {"inserted": 0, "updated": 0},
+        "outcomes": {"inserted": 0, "updated": 0},
+        "funding_resources": {"inserted": 0, "updated": 0},
+        "beneficiaries": {"inserted": 0, "updated": 0},
+    }
+
+    try:
+        # Projects ---------------------------------------------------------
+        project_rows = (
+            session.query(StgProjectInfo)
+            .filter(
+                StgProjectInfo.import_batch_id == import_batch_id,
+                StgProjectInfo.parse_errors.is_(None),
+            )
+            .all()
+        )
+        for row in project_rows:
+            data = row.raw_json
+            owner = data.get("owner_org_id")
+            pid = data.get("project_id")
+            existing = (
+                session.query(Project)
+                .filter_by(owner_org_id=owner, project_id=pid)
+                .one_or_none()
+            )
+            if existing:
+                if existing.row_hash != row.row_hash:
+                    existing.name = data.get("name")
+                    existing.org_name = data.get("org_name")
+                    existing.start_date = _parse_date(data.get("start_date"))
+                    existing.end_date = _parse_date(data.get("end_date"))
+                    existing.country = data.get("country")
+                    existing.region = data.get("region")
+                    existing.sdg_goal = data.get("sdg_goal")
+                    existing.notes = data.get("notes")
+                    existing.row_hash = row.row_hash
+                    existing.source_system = row.source_system
+                    existing.external_id = row.external_id
+                    existing.ingested_at = row.ingested_at
+                    existing.import_batch_id = row.import_batch_id
+                    existing.schema_version = row.schema_version
+                    counts["projects"]["updated"] += 1
+            else:
+                proj = Project(
+                    id=str(uuid.uuid4()),
+                    owner_org_id=owner,
+                    project_id=pid,
+                    name=data.get("name"),
+                    org_name=data.get("org_name"),
+                    start_date=_parse_date(data.get("start_date")),
+                    end_date=_parse_date(data.get("end_date")),
+                    country=data.get("country"),
+                    region=data.get("region"),
+                    sdg_goal=data.get("sdg_goal"),
+                    notes=data.get("notes"),
+                    row_hash=row.row_hash,
+                    source_system=row.source_system,
+                    external_id=row.external_id,
+                    ingested_at=row.ingested_at,
+                    import_batch_id=row.import_batch_id,
+                    schema_version=row.schema_version,
+                )
+                session.add(proj)
+                counts["projects"]["inserted"] += 1
+
+        # ensure projects are flushed so children can reference them
+        session.flush()
+
+        # Activities ------------------------------------------------------
+        activity_rows = (
+            session.query(StgActivity)
+            .filter(
+                StgActivity.import_batch_id == import_batch_id,
+                StgActivity.parse_errors.is_(None),
+            )
+            .all()
+        )
+        for row in activity_rows:
+            data = row.raw_json
+            owner = data.get("owner_org_id")
+            pid = data.get("project_id")
+            project = (
+                session.query(Project)
+                .filter_by(owner_org_id=owner, project_id=pid)
+                .one_or_none()
+            )
+            project_fk = project.id if project else data.get("project_id")
+            existing = session.query(Activity).filter(Activity.row_hash == row.row_hash).one_or_none()
+            if not existing:
+                existing = (
+                    session.query(Activity)
+                    .filter(
+                        Activity.project_fk == project_fk,
+                        Activity.activity_name == data.get("activity_name"),
+                        Activity.date == _parse_date(data.get("date")),
+                    )
+                    .one_or_none()
+                )
+            if existing:
+                if existing.row_hash != row.row_hash:
+                    existing.activity_type = data.get("activity_type")
+                    existing.beneficiaries_reached = _parse_int(
+                        data.get("beneficiaries_reached")
+                    )
+                    existing.location = data.get("location")
+                    existing.notes = data.get("notes")
+                    existing.row_hash = row.row_hash
+                    existing.source_system = row.source_system
+                    existing.external_id = row.external_id
+                    existing.ingested_at = row.ingested_at
+                    existing.import_batch_id = row.import_batch_id
+                    existing.schema_version = row.schema_version
+                    counts["activities"]["updated"] += 1
+            else:
+                obj = Activity(
+                    id=str(uuid.uuid4()),
+                    project_fk=project_fk,
+                    date=_parse_date(data.get("date")),
+                    activity_type=data.get("activity_type"),
+                    activity_name=data.get("activity_name"),
+                    beneficiaries_reached=_parse_int(
+                        data.get("beneficiaries_reached")
+                    ),
+                    location=data.get("location"),
+                    notes=data.get("notes"),
+                    row_hash=row.row_hash,
+                    source_system=row.source_system,
+                    external_id=row.external_id,
+                    ingested_at=row.ingested_at,
+                    import_batch_id=row.import_batch_id,
+                    schema_version=row.schema_version,
+                )
+                session.add(obj)
+                counts["activities"]["inserted"] += 1
+
+        # Outcomes --------------------------------------------------------
+        outcome_rows = (
+            session.query(StgOutcome)
+            .filter(
+                StgOutcome.import_batch_id == import_batch_id,
+                StgOutcome.parse_errors.is_(None),
+            )
+            .all()
+        )
+        for row in outcome_rows:
+            data = row.raw_json
+            owner = data.get("owner_org_id")
+            pid = data.get("project_id")
+            project = (
+                session.query(Project)
+                .filter_by(owner_org_id=owner, project_id=pid)
+                .one_or_none()
+            )
+            project_fk = project.id if project else data.get("project_id")
+            existing = session.query(Outcome).filter(Outcome.row_hash == row.row_hash).one_or_none()
+            if not existing:
+                existing = (
+                    session.query(Outcome)
+                    .filter(
+                        Outcome.project_fk == project_fk,
+                        Outcome.outcome_metric == data.get("outcome_metric"),
+                        Outcome.date == _parse_date(data.get("date")),
+                    )
+                    .one_or_none()
+                )
+            if existing:
+                if existing.row_hash != row.row_hash:
+                    existing.value = _parse_float(data.get("value"))
+                    existing.unit = data.get("unit")
+                    existing.method = data.get("method")
+                    existing.notes = data.get("notes")
+                    existing.row_hash = row.row_hash
+                    existing.source_system = row.source_system
+                    existing.external_id = row.external_id
+                    existing.ingested_at = row.ingested_at
+                    existing.import_batch_id = row.import_batch_id
+                    existing.schema_version = row.schema_version
+                    counts["outcomes"]["updated"] += 1
+            else:
+                obj = Outcome(
+                    id=str(uuid.uuid4()),
+                    project_fk=project_fk,
+                    date=_parse_date(data.get("date")),
+                    outcome_metric=data.get("outcome_metric"),
+                    value=_parse_float(data.get("value")),
+                    unit=data.get("unit"),
+                    method=data.get("method"),
+                    notes=data.get("notes"),
+                    row_hash=row.row_hash,
+                    source_system=row.source_system,
+                    external_id=row.external_id,
+                    ingested_at=row.ingested_at,
+                    import_batch_id=row.import_batch_id,
+                    schema_version=row.schema_version,
+                )
+                session.add(obj)
+                counts["outcomes"]["inserted"] += 1
+
+        # Funding resources -----------------------------------------------
+        fr_rows = (
+            session.query(StgFundingResource)
+            .filter(
+                StgFundingResource.import_batch_id == import_batch_id,
+                StgFundingResource.parse_errors.is_(None),
+            )
+            .all()
+        )
+        for row in fr_rows:
+            data = row.raw_json
+            owner = data.get("owner_org_id")
+            pid = data.get("project_id")
+            project = (
+                session.query(Project)
+                .filter_by(owner_org_id=owner, project_id=pid)
+                .one_or_none()
+            )
+            project_fk = project.id if project else data.get("project_id")
+            existing = session.query(FundingResource).filter(FundingResource.row_hash == row.row_hash).one_or_none()
+            if not existing:
+                existing = (
+                    session.query(FundingResource)
+                    .filter(
+                        FundingResource.project_fk == project_fk,
+                        FundingResource.funding_source == data.get("funding_source"),
+                        FundingResource.date == _parse_date(data.get("date")),
+                    )
+                    .one_or_none()
+                )
+            if existing:
+                if existing.row_hash != row.row_hash:
+                    existing.received = _parse_float(data.get("received"))
+                    existing.spent = _parse_float(data.get("spent"))
+                    existing.volunteer_hours = _parse_float(
+                        data.get("volunteer_hours")
+                    )
+                    existing.staff_hours = _parse_float(data.get("staff_hours"))
+                    existing.notes = data.get("notes")
+                    existing.row_hash = row.row_hash
+                    existing.source_system = row.source_system
+                    existing.external_id = row.external_id
+                    existing.ingested_at = row.ingested_at
+                    existing.import_batch_id = row.import_batch_id
+                    existing.schema_version = row.schema_version
+                    counts["funding_resources"]["updated"] += 1
+            else:
+                obj = FundingResource(
+                    id=str(uuid.uuid4()),
+                    project_fk=project_fk,
+                    date=_parse_date(data.get("date")),
+                    funding_source=data.get("funding_source"),
+                    received=_parse_float(data.get("received")),
+                    spent=_parse_float(data.get("spent")),
+                    volunteer_hours=_parse_float(data.get("volunteer_hours")),
+                    staff_hours=_parse_float(data.get("staff_hours")),
+                    notes=data.get("notes"),
+                    row_hash=row.row_hash,
+                    source_system=row.source_system,
+                    external_id=row.external_id,
+                    ingested_at=row.ingested_at,
+                    import_batch_id=row.import_batch_id,
+                    schema_version=row.schema_version,
+                )
+                session.add(obj)
+                counts["funding_resources"]["inserted"] += 1
+
+        # Beneficiaries ---------------------------------------------------
+        ben_rows = (
+            session.query(StgBeneficiary)
+            .filter(
+                StgBeneficiary.import_batch_id == import_batch_id,
+                StgBeneficiary.parse_errors.is_(None),
+            )
+            .all()
+        )
+        for row in ben_rows:
+            data = row.raw_json
+            owner = data.get("owner_org_id")
+            pid = data.get("project_id")
+            project = (
+                session.query(Project)
+                .filter_by(owner_org_id=owner, project_id=pid)
+                .one_or_none()
+            )
+            project_fk = project.id if project else data.get("project_id")
+            existing = session.query(Beneficiary).filter(Beneficiary.row_hash == row.row_hash).one_or_none()
+            if not existing:
+                existing = (
+                    session.query(Beneficiary)
+                    .filter(
+                        Beneficiary.project_fk == project_fk,
+                        Beneficiary.group == data.get("group"),
+                        Beneficiary.date == _parse_date(data.get("date")),
+                    )
+                    .one_or_none()
+                )
+            if existing:
+                if existing.row_hash != row.row_hash:
+                    existing.count = _parse_int(data.get("count"))
+                    existing.demographic_info = data.get("demographic_info")
+                    existing.location = data.get("location")
+                    existing.notes = data.get("notes")
+                    existing.row_hash = row.row_hash
+                    existing.source_system = row.source_system
+                    existing.external_id = row.external_id
+                    existing.ingested_at = row.ingested_at
+                    existing.import_batch_id = row.import_batch_id
+                    existing.schema_version = row.schema_version
+                    counts["beneficiaries"]["updated"] += 1
+            else:
+                obj = Beneficiary(
+                    id=str(uuid.uuid4()),
+                    project_fk=project_fk,
+                    date=_parse_date(data.get("date")),
+                    group=data.get("group"),
+                    count=_parse_int(data.get("count")),
+                    demographic_info=data.get("demographic_info"),
+                    location=data.get("location"),
+                    notes=data.get("notes"),
+                    row_hash=row.row_hash,
+                    source_system=row.source_system,
+                    external_id=row.external_id,
+                    ingested_at=row.ingested_at,
+                    import_batch_id=row.import_batch_id,
+                    schema_version=row.schema_version,
+                )
+                session.add(obj)
+                counts["beneficiaries"]["inserted"] += 1
+
+        session.commit()
+        return counts
+    finally:
+        session.close()
+

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -7,6 +7,8 @@ from .project import Project
 from .activity import Activity
 from .outcome import Outcome
 from .metric import Metric
+from .funding_resource import FundingResource
+from .beneficiary import Beneficiary
 from .integration import Integration
 from .investor import Investor
 from .audit_log import AuditLog

--- a/backend/app/models/beneficiary.py
+++ b/backend/app/models/beneficiary.py
@@ -16,15 +16,15 @@ from sqlalchemy.sql import func
 from ..database import Base
 
 
-class Activity(Base):
-    __tablename__ = "activities"
+class Beneficiary(Base):
+    __tablename__ = "beneficiaries"
 
     id = Column(String, primary_key=True)
     project_fk = Column(String, ForeignKey("projects.id"), nullable=False)
     date = Column(Date, nullable=True)
-    activity_type = Column(String, nullable=True)
-    activity_name = Column(String, nullable=True)
-    beneficiaries_reached = Column(Integer, nullable=True)
+    group = Column(String, nullable=True)
+    count = Column(Integer, nullable=True)
+    demographic_info = Column(String, nullable=True)
     location = Column(String, nullable=True)
     notes = Column(Text, nullable=True)
 
@@ -39,10 +39,8 @@ class Activity(Base):
     schema_version = Column(Integer, nullable=False, server_default="1")
 
     __table_args__ = (
-        UniqueConstraint(
-            "project_fk", "activity_name", "date", name="uq_activity_natural"
-        ),
+        UniqueConstraint("project_fk", "group", "date", name="uq_beneficiary_natural"),
     )
 
-    project = relationship("Project", back_populates="activities")
+    project = relationship("Project", back_populates="beneficiaries")
 

--- a/backend/app/models/funding_resource.py
+++ b/backend/app/models/funding_resource.py
@@ -4,6 +4,7 @@ from sqlalchemy import (
     Column,
     Date,
     DateTime,
+    Float,
     ForeignKey,
     Integer,
     String,
@@ -16,16 +17,17 @@ from sqlalchemy.sql import func
 from ..database import Base
 
 
-class Activity(Base):
-    __tablename__ = "activities"
+class FundingResource(Base):
+    __tablename__ = "funding_resources"
 
     id = Column(String, primary_key=True)
     project_fk = Column(String, ForeignKey("projects.id"), nullable=False)
     date = Column(Date, nullable=True)
-    activity_type = Column(String, nullable=True)
-    activity_name = Column(String, nullable=True)
-    beneficiaries_reached = Column(Integer, nullable=True)
-    location = Column(String, nullable=True)
+    funding_source = Column(String, nullable=True)
+    received = Column(Float, nullable=True)
+    spent = Column(Float, nullable=True)
+    volunteer_hours = Column(Float, nullable=True)
+    staff_hours = Column(Float, nullable=True)
     notes = Column(Text, nullable=True)
 
     # lineage fields
@@ -40,9 +42,9 @@ class Activity(Base):
 
     __table_args__ = (
         UniqueConstraint(
-            "project_fk", "activity_name", "date", name="uq_activity_natural"
+            "project_fk", "funding_source", "date", name="uq_funding_natural"
         ),
     )
 
-    project = relationship("Project", back_populates="activities")
+    project = relationship("Project", back_populates="funding_resources")
 

--- a/backend/app/models/metric.py
+++ b/backend/app/models/metric.py
@@ -9,7 +9,7 @@ class Metric(Base):
     __tablename__ = "metrics"
 
     id = Column(Integer, primary_key=True, index=True)
-    outcome_id = Column(Integer, ForeignKey("outcomes.id"), nullable=False)
+    outcome_id = Column(String, ForeignKey("outcomes.id"), nullable=False)
     name = Column(String, nullable=False)
     value = Column(Float, nullable=True)
     recorded_at = Column(DateTime(timezone=True), server_default=func.now())

--- a/backend/app/models/outcome.py
+++ b/backend/app/models/outcome.py
@@ -1,25 +1,50 @@
-from sqlalchemy import Column, Integer, String, Text, DateTime, ForeignKey
-from sqlalchemy.sql import func
+from __future__ import annotations
+
+from sqlalchemy import (
+    Column,
+    Date,
+    DateTime,
+    Float,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+)
 from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
 
 from ..database import Base
-from .metric import Metric
 
 
 class Outcome(Base):
     __tablename__ = "outcomes"
 
-    id = Column(Integer, primary_key=True, index=True)
-    activity_id = Column(Integer, ForeignKey("activities.id"), nullable=False)
-    name = Column(String, nullable=False)
-    description = Column(Text, nullable=True)
-    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    id = Column(String, primary_key=True)
+    project_fk = Column(String, ForeignKey("projects.id"), nullable=False)
+    date = Column(Date, nullable=True)
+    outcome_metric = Column(String, nullable=True)
+    value = Column(Float, nullable=True)
+    unit = Column(String, nullable=True)
+    method = Column(String, nullable=True)
+    notes = Column(Text, nullable=True)
+
+    # lineage fields
     source_system = Column(String, nullable=False, server_default="excel")
     external_id = Column(String, nullable=True)
-    ingested_at = Column(DateTime(timezone=True), server_default=func.now())
+    ingested_at = Column(
+        DateTime(timezone=True), server_default=func.now(), nullable=True
+    )
     row_hash = Column(String, nullable=True)
     import_batch_id = Column(String, ForeignKey("import_batches.id"), nullable=True)
     schema_version = Column(Integer, nullable=False, server_default="1")
 
-    activity = relationship("Activity", back_populates="outcomes")
+    __table_args__ = (
+        UniqueConstraint(
+            "project_fk", "outcome_metric", "date", name="uq_outcome_natural"
+        ),
+    )
+
+    project = relationship("Project", back_populates="outcomes")
     metrics = relationship("Metric", back_populates="outcome", cascade="all, delete-orphan")
+

--- a/backend/app/models/project.py
+++ b/backend/app/models/project.py
@@ -1,27 +1,68 @@
-from sqlalchemy import Column, Integer, String, Text, DateTime, ForeignKey
-from sqlalchemy.sql import func
+from __future__ import annotations
+
+from sqlalchemy import (
+    Column,
+    Date,
+    DateTime,
+    Integer,
+    ForeignKey,
+    String,
+    Text,
+    UniqueConstraint,
+)
 from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
 
 from ..database import Base
-from .activity import Activity
 
 
 class Project(Base):
+    """Core project table.
+
+    Projects are uniquely identified by the tuple
+    ``(owner_org_id, project_id)``.  The ``id`` column is a surrogate
+    primary key used by child tables.
+    """
+
     __tablename__ = "projects"
 
-    id = Column(Integer, primary_key=True, index=True)
-    user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
-    name = Column(String, nullable=False)
-    description = Column(Text, nullable=True)
-    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    id = Column(String, primary_key=True)
+    owner_org_id = Column(String, nullable=False)
+    project_id = Column(String, nullable=False)
+    name = Column(String, nullable=True)
+    org_name = Column(String, nullable=True)
+    start_date = Column(Date, nullable=True)
+    end_date = Column(Date, nullable=True)
+    country = Column(String, nullable=True)
+    region = Column(String, nullable=True)
+    sdg_goal = Column(String, nullable=True)
+    notes = Column(Text, nullable=True)
+
+    # lineage fields
     source_system = Column(String, nullable=False, server_default="excel")
     external_id = Column(String, nullable=True)
-    ingested_at = Column(DateTime(timezone=True), server_default=func.now())
+    ingested_at = Column(
+        DateTime(timezone=True), server_default=func.now(), nullable=True
+    )
     row_hash = Column(String, nullable=True)
     import_batch_id = Column(String, ForeignKey("import_batches.id"), nullable=True)
     schema_version = Column(Integer, nullable=False, server_default="1")
 
-    user = relationship("User", back_populates="projects")
+    __table_args__ = (
+        UniqueConstraint("owner_org_id", "project_id", name="uq_project_org_pid"),
+    )
+
     activities = relationship(
         "Activity", back_populates="project", cascade="all, delete-orphan"
     )
+    outcomes = relationship(
+        "Outcome", back_populates="project", cascade="all, delete-orphan"
+    )
+    funding_resources = relationship(
+        "FundingResource", back_populates="project", cascade="all, delete-orphan"
+    )
+    beneficiaries = relationship(
+        "Beneficiary", back_populates="project", cascade="all, delete-orphan"
+    )
+
+

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -25,5 +25,4 @@ class User(Base):
     dashboards = relationship("Dashboard", back_populates="user")
     integrations = relationship("Integration", back_populates="user")
     reports = relationship("Report", back_populates="user")
-    projects = relationship("Project", back_populates="user")
     audit_logs = relationship("AuditLog", back_populates="user")

--- a/backend/app/tests/test_load_to_core.py
+++ b/backend/app/tests/test_load_to_core.py
@@ -1,0 +1,243 @@
+from pathlib import Path
+import os
+import sys
+import uuid
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+# Setup environment and path
+sys.path.append(str(Path(__file__).resolve().parents[3]))
+os.environ["database_url"] = "sqlite:///./test.db"
+_db_path = Path("test.db")
+if _db_path.exists():
+    _db_path.unlink()
+os.environ.setdefault("jwt_secret", "test")
+os.environ.setdefault("openai_api_key", "test")
+os.environ.setdefault("xero_client_id", "test")
+os.environ.setdefault("xero_client_secret", "test")
+os.environ.setdefault("xero_redirect_uri", "http://localhost")
+os.environ.setdefault("google_client_id", "test")
+os.environ.setdefault("google_client_secret", "test")
+os.environ.setdefault("google_redirect_uri", "http://localhost")
+os.environ.setdefault("secret_key", "test")
+
+from backend.app.database import Base, engine, SessionLocal
+from backend.app.ingest.hash import canonical_row_hash
+from backend.app.ingest.load_to_core import load_to_core
+from backend.app.models import (
+    ImportBatch,
+    StgProjectInfo,
+    StgActivity,
+    StgOutcome,
+    StgFundingResource,
+    StgBeneficiary,
+    Project,
+    Activity,
+    Outcome,
+    FundingResource,
+    Beneficiary,
+)
+
+
+def setup_function(_):
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+
+def _add_import_batch(db, batch_id: str):
+    db.add(
+        ImportBatch(
+            id=batch_id,
+            source_system="excel",
+            schema_version=1,
+            triggered_by_user_id="user",
+        )
+    )
+
+
+def _stage_sample_data(batch_id: str):
+    db = SessionLocal()
+    _add_import_batch(db, batch_id)
+
+    project_data = {
+        "owner_org_id": "org1",
+        "project_id": "p1",
+        "name": "Project 1",
+        "org_name": "Org 1",
+        "start_date": "2024-01-01",
+        "end_date": "2024-12-31",
+        "country": "X",
+        "region": "Y",
+        "sdg_goal": "goal",
+        "notes": "n",
+    }
+    proj = StgProjectInfo(
+        id=str(uuid.uuid4()),
+        upload_id="u1",
+        row_num=1,
+        raw_json=project_data,
+        row_hash=canonical_row_hash(project_data),
+        import_batch_id=batch_id,
+        source_system="excel",
+        schema_version=1,
+    )
+    db.add(proj)
+
+    activity_data = {
+        "owner_org_id": "org1",
+        "project_id": "p1",
+        "date": "2024-02-01",
+        "activity_type": "type",
+        "activity_name": "act",
+        "beneficiaries_reached": 10,
+        "location": "loc",
+        "notes": "a",
+    }
+    db.add(
+        StgActivity(
+            id=str(uuid.uuid4()),
+            upload_id="u1",
+            row_num=1,
+            raw_json=activity_data,
+            row_hash=canonical_row_hash(activity_data),
+            import_batch_id=batch_id,
+            source_system="excel",
+            schema_version=1,
+        )
+    )
+
+    outcome_data = {
+        "owner_org_id": "org1",
+        "project_id": "p1",
+        "date": "2024-03-01",
+        "outcome_metric": "metric",
+        "value": 5,
+        "unit": "u",
+        "method": "m",
+        "notes": "o",
+    }
+    db.add(
+        StgOutcome(
+            id=str(uuid.uuid4()),
+            upload_id="u1",
+            row_num=1,
+            raw_json=outcome_data,
+            row_hash=canonical_row_hash(outcome_data),
+            import_batch_id=batch_id,
+            source_system="excel",
+            schema_version=1,
+        )
+    )
+
+    fr_data = {
+        "owner_org_id": "org1",
+        "project_id": "p1",
+        "date": "2024-04-01",
+        "funding_source": "donor",
+        "received": 100.0,
+        "spent": 80.0,
+        "volunteer_hours": 5,
+        "staff_hours": 3,
+        "notes": "f",
+    }
+    db.add(
+        StgFundingResource(
+            id=str(uuid.uuid4()),
+            upload_id="u1",
+            row_num=1,
+            raw_json=fr_data,
+            row_hash=canonical_row_hash(fr_data),
+            import_batch_id=batch_id,
+            source_system="excel",
+            schema_version=1,
+        )
+    )
+
+    ben_data = {
+        "owner_org_id": "org1",
+        "project_id": "p1",
+        "date": "2024-05-01",
+        "group": "g1",
+        "count": 20,
+        "demographic_info": "info",
+        "location": "loc",
+        "notes": "b",
+    }
+    db.add(
+        StgBeneficiary(
+            id=str(uuid.uuid4()),
+            upload_id="u1",
+            row_num=1,
+            raw_json=ben_data,
+            row_hash=canonical_row_hash(ben_data),
+            import_batch_id=batch_id,
+            source_system="excel",
+            schema_version=1,
+        )
+    )
+
+    db.commit()
+    db.close()
+
+
+def test_load_to_core_idempotent():
+    batch_id = str(uuid.uuid4())
+    _stage_sample_data(batch_id)
+
+    counts1 = load_to_core(batch_id)
+    assert counts1 == {
+        "projects": {"inserted": 1, "updated": 0},
+        "activities": {"inserted": 1, "updated": 0},
+        "outcomes": {"inserted": 1, "updated": 0},
+        "funding_resources": {"inserted": 1, "updated": 0},
+        "beneficiaries": {"inserted": 1, "updated": 0},
+    }
+
+    db = SessionLocal()
+    assert db.query(Project).count() == 1
+    assert db.query(Activity).count() == 1
+    assert db.query(Outcome).count() == 1
+    assert db.query(FundingResource).count() == 1
+    assert db.query(Beneficiary).count() == 1
+    db.close()
+
+    counts2 = load_to_core(batch_id)
+    assert counts2 == {
+        "projects": {"inserted": 0, "updated": 0},
+        "activities": {"inserted": 0, "updated": 0},
+        "outcomes": {"inserted": 0, "updated": 0},
+        "funding_resources": {"inserted": 0, "updated": 0},
+        "beneficiaries": {"inserted": 0, "updated": 0},
+    }
+
+
+def test_load_to_core_fk_enforced():
+    batch_id = str(uuid.uuid4())
+    db = SessionLocal()
+    _add_import_batch(db, batch_id)
+    bad_activity = {
+        "owner_org_id": "org1",
+        "project_id": "missing",
+        "date": "2024-01-01",
+        "activity_type": "t",
+        "activity_name": "a",
+    }
+    db.add(
+        StgActivity(
+            id=str(uuid.uuid4()),
+            upload_id="u1",
+            row_num=1,
+            raw_json=bad_activity,
+            row_hash=canonical_row_hash(bad_activity),
+            import_batch_id=batch_id,
+            source_system="excel",
+            schema_version=1,
+        )
+    )
+    db.commit()
+    db.close()
+
+    with pytest.raises(IntegrityError):
+        load_to_core(batch_id)
+


### PR DESCRIPTION
## Summary
- define core domain tables for projects and related entities with lineage and FK constraints
- add loader that upserts data from staging tables using natural keys and row hashes
- test idempotent ingestion and foreign-key enforcement

## Testing
- `pytest backend/app/tests/test_load_to_core.py -q`
- `pytest backend/app/tests -q` *(fails: UNIQUE constraint failed: users.id / readonly database)*

------
https://chatgpt.com/codex/tasks/task_e_68ac4159c334832b8d9a267a97a3f6ec