### PR TITLE
Implement deterministic row hashing with canonicalization

### DIFF
--- a/backend/app/ingest/hash.py
+++ b/backend/app/ingest/hash.py
@@ -1,16 +1,42 @@
+import datetime
 import hashlib
 import json
 import math
 from typing import Any, Dict
 
 
+def canonicalize(value: Any) -> Any:
+    """Recursively normalize values for stable hashing.
+
+    - Dict keys are sorted.
+    - Strings are trimmed and lower-cased.
+    - ISO formatted dates are normalized.
+    - NaN floats are converted to ``None``.
+    """
+
+    if isinstance(value, dict):
+        return {k: canonicalize(v) for k, v in sorted(value.items(), key=lambda kv: kv[0])}
+    if isinstance(value, list):
+        return [canonicalize(v) for v in value]
+    if isinstance(value, str):
+        v = value.strip().lower()
+        candidate = v[:-1] if v.endswith("z") else v
+        for parser in (datetime.datetime.fromisoformat, datetime.date.fromisoformat):
+            try:
+                return parser(candidate).isoformat()
+            except ValueError:
+                continue
+        return v
+    if isinstance(value, float) and math.isnan(value):
+        return None
+    if isinstance(value, (datetime.datetime, datetime.date)):
+        return value.isoformat()
+    return value
+
+
 def canonical_row_hash(row: Dict[str, Any]) -> str:
-    """Return a stable hash for a row of data."""
-    cleaned: Dict[str, Any] = {}
-    for key, value in row.items():
-        if isinstance(value, float) and math.isnan(value):
-            cleaned[key] = None
-        else:
-            cleaned[key] = value
-    encoded = json.dumps(cleaned, sort_keys=True, default=str)
-    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+    """Return a deterministic SHA256 hash for a row of data."""
+
+    payload = json.dumps(canonicalize(row), separators=(",", ":"), ensure_ascii=False)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+

--- a/backend/tests/test_hash.py
+++ b/backend/tests/test_hash.py
@@ -1,0 +1,41 @@
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
+
+from backend.app.ingest.hash import canonical_row_hash
+
+
+def test_hash_stability():
+    row_one = {"b": "2", "a": "1"}
+    row_two = {"a": "1", "b": "2"}
+
+    assert canonical_row_hash(row_one) == canonical_row_hash(row_two)
+
+
+def test_whitespace_and_case_tolerance():
+    row_one = {"name": " Alice "}
+    row_two = {"name": "alice"}
+
+    assert canonical_row_hash(row_one) == canonical_row_hash(row_two)
+
+
+def test_only_changed_rows_update():
+    original = [
+        {"id": 1, "name": "alice"},
+        {"id": 2, "name": "bob"},
+    ]
+    original_hashes = {r["id"]: canonical_row_hash(r) for r in original}
+
+    updated = [
+        {"id": 1, "name": " Alice "},  # unchanged after canonicalization
+        {"id": 2, "name": "Bobby"},  # changed
+    ]
+    changed = [
+        row["id"]
+        for row in updated
+        if canonical_row_hash(row) != original_hashes.get(row["id"])
+    ]
+
+    assert changed == [2]
+


### PR DESCRIPTION
## Summary
- add canonicalize utility to normalize whitespace, case, dates, and NaN values
- compute stable SHA256 hash for rows using canonical form
- add tests for hash stability and idempotent row updates

## Testing
- `pytest` *(fails: sqlite3 IntegrityError and OperationalError during collection)*
- `pytest tests/test_hash.py -vv`

------
https://chatgpt.com/codex/tasks/task_e_68ac45c79624832bb4ec1756b8c95adb