### PR TITLE
Wire ingestion job worker flow with Celery

### DIFF
--- a/backend/worker/tasks/ingest_excel_or_csv.py
+++ b/backend/worker/tasks/ingest_excel_or_csv.py
@@ -1,0 +1,93 @@
+import time
+from dataclasses import dataclass
+from typing import Dict, Any
+
+from ..worker import app
+
+
+@dataclass
+class StepCounts:
+    fetched: int = 0
+    staged: int = 0
+    loaded: int = 0
+
+
+def _close_db(db) -> None:
+    try:
+        db.close()
+    except Exception:
+        pass
+
+
+@app.task(bind=True)
+def ingest_excel_or_csv(self, job_id: int) -> Dict[str, Any]:
+    """Ingest an uploaded Excel/CSV file identified by an ingestion job."""
+    from backend.app.database import SessionLocal
+    from backend.app.models.ingestion_jobs import IngestionJob, IngestionJobStatus
+    from backend.app.models.import_batches import ImportBatch, BatchStatus
+    from backend.app.observability.events import log_event
+
+    start_time = time.time()
+    db = SessionLocal()
+
+    job: IngestionJob | None = db.query(IngestionJob).filter(IngestionJob.id == job_id).first()
+    if job is None:
+        _close_db(db)
+        return {"status": "missing"}
+
+    batch: ImportBatch | None = (
+        db.query(ImportBatch).filter(ImportBatch.id == job.import_batch_id).first()
+    )
+    counts = StepCounts()
+
+    try:
+        job.status = IngestionJobStatus.running
+        if batch is not None:
+            batch.set_status(BatchStatus.running)
+        db.commit()
+        log_event("ingest_started", job_id=job.id, import_batch_id=job.import_batch_id)
+
+        # fetch
+        log_event("ingest_fetch", job_id=job.id)
+        # validate
+        log_event("ingest_validate", job_id=job.id)
+        # stage
+        log_event("ingest_stage", job_id=job.id)
+        # normalize
+        log_event("ingest_normalize", job_id=job.id)
+        # load
+        log_event("ingest_load", job_id=job.id)
+
+        job.status = IngestionJobStatus.success
+        if batch is not None:
+            batch.set_status(BatchStatus.success)
+        db.commit()
+
+        duration_ms = int((time.time() - start_time) * 1000)
+        log_event(
+            "ingest_completed",
+            job_id=job.id,
+            import_batch_id=job.import_batch_id,
+            duration_ms=duration_ms,
+            counts=counts.__dict__,
+        )
+        return {"status": "success", "duration_ms": duration_ms}
+    except Exception as exc:  # pragma: no cover - exercised in tests
+        db.rollback()
+        error_json = {"error": str(exc), "sheet": None, "row": None}
+        job.status = IngestionJobStatus.failed
+        job.error_json = error_json
+        if batch is not None:
+            batch.set_status(BatchStatus.failed, error_json)
+        db.commit()
+        duration_ms = int((time.time() - start_time) * 1000)
+        log_event(
+            "ingest_failed",
+            job_id=job.id,
+            import_batch_id=job.import_batch_id,
+            duration_ms=duration_ms,
+            error=error_json,
+        )
+        raise
+    finally:
+        _close_db(db)

--- a/backend/worker/worker.py
+++ b/backend/worker/worker.py
@@ -2,7 +2,7 @@ import os
 from celery import Celery
 from celery.signals import worker_ready, worker_shutdown
 
-from app.observability.events import log_event
+from backend.app.observability.events import log_event
 
 REDIS_URL = os.environ.get("REDIS_URL", "redis://localhost:6379/0")
 WORKER_CONCURRENCY = int(os.environ.get("WORKER_CONCURRENCY", "2"))
@@ -47,3 +47,6 @@ def _on_worker_ready(**_):
 @worker_shutdown.connect
 def _on_worker_shutdown(**_):
     log_event("worker_shutdown", org_id=ORG_ID, project_id=PROJECT_ID)
+
+# Ensure tasks are registered
+from .tasks import ingest_excel_or_csv  # noqa: F401


### PR DESCRIPTION
## Summary
- add Celery task `ingest_excel_or_csv` to handle ingestion lifecycle and status updates
- enqueue ingestion job from `/ingest/jobs` endpoint and log events
- ensure worker registers tasks for execution

## Testing
- `pytest` *(fails: sqlite3.IntegrityError UNIQUE constraint failed: users.id; sqlite3.OperationalError attempt to write a readonly database)*

------
https://chatgpt.com/codex/tasks/task_e_68ac46d2104c832ba34b42b432e50964