### PR TITLE
Add KPI summary tables and rollup computation

### DIFF
--- a/backend/alembic/versions/aa1b2c3d4e5f_create_summary_tables.py
+++ b/backend/alembic/versions/aa1b2c3d4e5f_create_summary_tables.py
@@ -1,0 +1,49 @@
+"""create summary tables"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "aa1b2c3d4e5f"
+down_revision = "47d816f245d2"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "project_summary",
+        sa.Column("project_fk", sa.String(), sa.ForeignKey("projects.id"), primary_key=True),
+        sa.Column("total_received", sa.Float(), nullable=False, server_default="0"),
+        sa.Column("total_spent", sa.Float(), nullable=False, server_default="0"),
+        sa.Column("total_beneficiaries", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("cost_per_beneficiary", sa.Float(), nullable=True),
+    )
+
+    op.create_table(
+        "monthly_rollups",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("project_fk", sa.String(), sa.ForeignKey("projects.id"), nullable=False),
+        sa.Column("month", sa.Date(), nullable=False),
+        sa.Column("total_received", sa.Float(), nullable=False, server_default="0"),
+        sa.Column("total_spent", sa.Float(), nullable=False, server_default="0"),
+        sa.Column("total_beneficiaries", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("cost_per_beneficiary", sa.Float(), nullable=True),
+        sa.Column("source_system", sa.String(), nullable=False, server_default="derived"),
+        sa.UniqueConstraint("project_fk", "month", name="uq_rollup_project_month"),
+    )
+
+    op.create_table(
+        "metrics_summary",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("project_fk", sa.String(), sa.ForeignKey("projects.id"), nullable=False),
+        sa.Column("metric_name", sa.String(), nullable=False),
+        sa.Column("total_value", sa.Float(), nullable=True),
+        sa.UniqueConstraint("project_fk", "metric_name", name="uq_metric_project_name"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("metrics_summary")
+    op.drop_table("monthly_rollups")
+    op.drop_table("project_summary")

--- a/backend/app/metrics/compute.py
+++ b/backend/app/metrics/compute.py
@@ -1,0 +1,116 @@
+from collections import defaultdict
+
+from sqlalchemy.orm import Session
+
+from ..models import (
+    Beneficiary,
+    FundingResource,
+    Outcome,
+    ProjectSummary,
+    MonthlyRollup,
+    MetricsSummary,
+)
+
+
+def recompute_for_project(db: Session, project_fk: str) -> None:
+    """Recompute summary tables for a given project.
+
+    Existing summary data for the project is removed before new values are
+    calculated. The function commits the session when finished.
+    """
+
+    # Clear existing summaries
+    db.query(ProjectSummary).filter_by(project_fk=project_fk).delete()
+    db.query(MonthlyRollup).filter_by(project_fk=project_fk).delete()
+    db.query(MetricsSummary).filter_by(project_fk=project_fk).delete()
+    db.flush()
+
+    # Project level totals
+    total_received = (
+        db.query(FundingResource)
+        .filter_by(project_fk=project_fk)
+        .with_entities(FundingResource.received)
+    )
+    total_received = sum(fr.received or 0 for fr in total_received)
+
+    total_spent = (
+        db.query(FundingResource)
+        .filter_by(project_fk=project_fk)
+        .with_entities(FundingResource.spent)
+    )
+    total_spent = sum(fr.spent or 0 for fr in total_spent)
+
+    total_beneficiaries = (
+        db.query(Beneficiary)
+        .filter_by(project_fk=project_fk)
+        .with_entities(Beneficiary.count)
+    )
+    total_beneficiaries = sum(b.count or 0 for b in total_beneficiaries)
+
+    cost_per_beneficiary = (
+        total_spent / total_beneficiaries if total_beneficiaries else None
+    )
+
+    db.add(
+        ProjectSummary(
+            project_fk=project_fk,
+            total_received=total_received,
+            total_spent=total_spent,
+            total_beneficiaries=total_beneficiaries,
+            cost_per_beneficiary=cost_per_beneficiary,
+        )
+    )
+
+    # Monthly rollups
+    monthly = defaultdict(lambda: {"received": 0.0, "spent": 0.0, "beneficiaries": 0})
+
+    for fr in db.query(FundingResource).filter_by(project_fk=project_fk):
+        if fr.date is None:
+            continue
+        month = fr.date.replace(day=1)
+        monthly[month]["received"] += fr.received or 0
+        monthly[month]["spent"] += fr.spent or 0
+
+    for ben in db.query(Beneficiary).filter_by(project_fk=project_fk):
+        if ben.date is None:
+            continue
+        month = ben.date.replace(day=1)
+        monthly[month]["beneficiaries"] += ben.count or 0
+
+    for month, vals in monthly.items():
+        cost = (
+            vals["spent"] / vals["beneficiaries"]
+            if vals["beneficiaries"]
+            else None
+        )
+        db.add(
+            MonthlyRollup(
+                project_fk=project_fk,
+                month=month,
+                total_received=vals["received"],
+                total_spent=vals["spent"],
+                total_beneficiaries=vals["beneficiaries"],
+                cost_per_beneficiary=cost,
+                source_system="derived",
+            )
+        )
+
+    # Metrics summary from outcomes
+    q = (
+        db.query(Outcome.outcome_metric, Outcome.value)
+        .filter(Outcome.project_fk == project_fk)
+    )
+    metrics = defaultdict(float)
+    for metric_name, value in q:
+        metrics[metric_name] += value or 0
+
+    for metric_name, total in metrics.items():
+        db.add(
+            MetricsSummary(
+                project_fk=project_fk,
+                metric_name=metric_name,
+                total_value=total,
+            )
+        )
+
+    db.commit()

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -9,6 +9,9 @@ from .outcome import Outcome
 from .metric import Metric
 from .funding_resource import FundingResource
 from .beneficiary import Beneficiary
+from .project_summary import ProjectSummary
+from .monthly_rollup import MonthlyRollup
+from .metrics_summary import MetricsSummary
 from .integration import Integration
 from .investor import Investor
 from .audit_log import AuditLog

--- a/backend/app/models/metrics_summary.py
+++ b/backend/app/models/metrics_summary.py
@@ -1,0 +1,18 @@
+from sqlalchemy import Column, Float, Integer, String, ForeignKey, UniqueConstraint
+from sqlalchemy.orm import relationship
+
+from ..database import Base
+
+class MetricsSummary(Base):
+    __tablename__ = "metrics_summary"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    project_fk = Column(String, ForeignKey("projects.id"), nullable=False, index=True)
+    metric_name = Column(String, nullable=False)
+    total_value = Column(Float, nullable=True)
+
+    project = relationship("Project", backref="metrics_summary")
+
+    __table_args__ = (
+        UniqueConstraint("project_fk", "metric_name", name="uq_metric_project_name"),
+    )

--- a/backend/app/models/monthly_rollup.py
+++ b/backend/app/models/monthly_rollup.py
@@ -1,0 +1,22 @@
+from sqlalchemy import Column, Date, Float, Integer, String, ForeignKey, UniqueConstraint
+from sqlalchemy.orm import relationship
+
+from ..database import Base
+
+class MonthlyRollup(Base):
+    __tablename__ = "monthly_rollups"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    project_fk = Column(String, ForeignKey("projects.id"), nullable=False, index=True)
+    month = Column(Date, nullable=False)
+    total_received = Column(Float, nullable=False, default=0)
+    total_spent = Column(Float, nullable=False, default=0)
+    total_beneficiaries = Column(Integer, nullable=False, default=0)
+    cost_per_beneficiary = Column(Float, nullable=True)
+    source_system = Column(String, nullable=False, default="derived")
+
+    project = relationship("Project", backref="monthly_rollups")
+
+    __table_args__ = (
+        UniqueConstraint("project_fk", "month", name="uq_rollup_project_month"),
+    )

--- a/backend/app/models/project_summary.py
+++ b/backend/app/models/project_summary.py
@@ -1,0 +1,15 @@
+from sqlalchemy import Column, Float, Integer, String, ForeignKey
+from sqlalchemy.orm import relationship
+
+from ..database import Base
+
+class ProjectSummary(Base):
+    __tablename__ = "project_summary"
+
+    project_fk = Column(String, ForeignKey("projects.id"), primary_key=True)
+    total_received = Column(Float, nullable=False, default=0)
+    total_spent = Column(Float, nullable=False, default=0)
+    total_beneficiaries = Column(Integer, nullable=False, default=0)
+    cost_per_beneficiary = Column(Float, nullable=True)
+
+    project = relationship("Project", backref="summary")

--- a/backend/app/tests/test_metrics_compute.py
+++ b/backend/app/tests/test_metrics_compute.py
@@ -1,0 +1,132 @@
+from pathlib import Path
+import os
+import sys
+from datetime import date
+import uuid
+
+# Setup environment and path
+sys.path.append(str(Path(__file__).resolve().parents[3]))
+os.environ["database_url"] = "sqlite:///./test.db"
+_db_path = Path("test.db")
+if _db_path.exists():
+    _db_path.unlink()
+os.environ.setdefault("jwt_secret", "test")
+os.environ.setdefault("openai_api_key", "test")
+os.environ.setdefault("xero_client_id", "test")
+os.environ.setdefault("xero_client_secret", "test")
+os.environ.setdefault("xero_redirect_uri", "http://localhost")
+os.environ.setdefault("google_client_id", "test")
+os.environ.setdefault("google_client_secret", "test")
+os.environ.setdefault("google_redirect_uri", "http://localhost")
+os.environ.setdefault("secret_key", "test")
+
+from backend.app.database import Base, engine, SessionLocal
+from backend.app.models import (
+    Project,
+    FundingResource,
+    Beneficiary,
+    Outcome,
+    ProjectSummary,
+    MonthlyRollup,
+    MetricsSummary,
+)
+from backend.app.metrics.compute import recompute_for_project
+
+
+def setup_function(_):
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+
+def test_metrics_compute():
+    db = SessionLocal()
+    project_id = "p1"
+    db.add(
+        Project(
+            id=project_id,
+            owner_org_id="org1",
+            project_id="p1",
+            name="Project 1",
+            source_system="excel",
+            schema_version=1,
+        )
+    )
+    db.add(
+        FundingResource(
+            id=str(uuid.uuid4()),
+            project_fk=project_id,
+            date=date(2024, 4, 1),
+            funding_source="donor",
+            received=100.0,
+            spent=80.0,
+            volunteer_hours=0,
+            staff_hours=0,
+            source_system="excel",
+            schema_version=1,
+        )
+    )
+    db.add(
+        Beneficiary(
+            id=str(uuid.uuid4()),
+            project_fk=project_id,
+            date=date(2024, 5, 1),
+            group="g1",
+            count=20,
+            demographic_info="info",
+            location="loc",
+            notes="b",
+            source_system="excel",
+            schema_version=1,
+        )
+    )
+    db.add(
+        Outcome(
+            id=str(uuid.uuid4()),
+            project_fk=project_id,
+            date=date(2024, 3, 1),
+            outcome_metric="metric",
+            value=5.0,
+            unit="u",
+            method="m",
+            notes="o",
+            source_system="excel",
+            schema_version=1,
+        )
+    )
+    db.commit()
+    db.close()
+
+    db = SessionLocal()
+    recompute_for_project(db, project_id)
+    db.close()
+
+    db = SessionLocal()
+    ps = db.query(ProjectSummary).filter_by(project_fk=project_id).one()
+    assert ps.total_received == 100.0
+    assert ps.total_spent == 80.0
+    assert ps.total_beneficiaries == 20
+    assert ps.cost_per_beneficiary == 4.0
+
+    rollups = {
+        r.month: r
+        for r in db.query(MonthlyRollup).filter_by(project_fk=project_id).all()
+    }
+    assert date(2024, 4, 1) in rollups
+    assert rollups[date(2024, 4, 1)].total_received == 100.0
+    assert rollups[date(2024, 4, 1)].total_spent == 80.0
+    assert rollups[date(2024, 4, 1)].total_beneficiaries == 0
+    assert rollups[date(2024, 4, 1)].cost_per_beneficiary is None
+    assert rollups[date(2024, 4, 1)].source_system == "derived"
+
+    assert date(2024, 5, 1) in rollups
+    assert rollups[date(2024, 5, 1)].total_beneficiaries == 20
+    assert rollups[date(2024, 5, 1)].total_spent == 0.0
+    assert rollups[date(2024, 5, 1)].cost_per_beneficiary == 0.0
+
+    ms = (
+        db.query(MetricsSummary)
+        .filter_by(project_fk=project_id, metric_name="metric")
+        .one()
+    )
+    assert ms.total_value == 5.0
+    db.close()


### PR DESCRIPTION
## Summary
- add project_summary, monthly_rollups, and metrics_summary tables
- compute project KPIs, monthly rollups, and metric aggregates with cost per beneficiary
- include source system in rollups for debugging

## Testing
- `pytest backend/app/tests/test_metrics_compute.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac4968a2c8832b8ea5cd49906bb207