### PR TITLE
Add metrics recompute task and API

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -14,6 +14,7 @@ from .api.routes import (
 from .routes.public.template import router as public_template_router
 from .routes.ingest.upload import router as ingest_upload_router
 from .routes.ingest.jobs import router as ingest_jobs_router
+from .routes.metrics.recompute import router as metrics_recompute_router
 
 app = FastAPI(
     title="ImpactView API",
@@ -41,6 +42,7 @@ app.include_router(investors_router, prefix="/api/v1")
 app.include_router(public_template_router)
 app.include_router(ingest_upload_router)
 app.include_router(ingest_jobs_router)
+app.include_router(metrics_recompute_router)
 
 @app.get("/")
 async def root():

--- a/backend/app/routes/metrics/recompute.py
+++ b/backend/app/routes/metrics/recompute.py
@@ -1,0 +1,48 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials
+from sqlalchemy.orm import Session
+from pydantic import BaseModel
+
+from ...api.deps import get_current_user, verify_token, security
+from ...database import get_db
+from ...models.user import User
+from ...models.project import Project
+from ....worker.tasks.recompute_metrics import recompute_metrics as recompute_metrics_task
+
+router = APIRouter(tags=["metrics"])
+
+
+class RecomputeRequest(BaseModel):
+    project_id: str | None = None
+
+
+@router.post("/metrics:recompute")
+def recompute_metrics_endpoint(
+    data: RecomputeRequest,
+    current_user: User = Depends(get_current_user),
+    creds: HTTPAuthorizationCredentials = Depends(security),
+    db: Session = Depends(get_db),
+):
+    payload = verify_token(creds.credentials)
+    org_id = payload.get("org_id") if payload else None
+    if org_id is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
+
+    user_roles = getattr(current_user, "roles", [])
+    is_admin = "admin" in user_roles
+
+    if data.project_id:
+        project = (
+            db.query(Project)
+            .filter(Project.id == data.project_id, Project.owner_org_id == str(org_id))
+            .first()
+        )
+        if project is None:
+            raise HTTPException(status_code=404, detail="Project not found")
+        counts = recompute_metrics_task(org_id=str(org_id), project_id=project.id)
+        return counts
+    else:
+        if not is_admin:
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Insufficient permissions")
+        counts = recompute_metrics_task(org_id=str(org_id))
+        return counts

--- a/backend/app/tests/test_metrics_recompute_endpoint.py
+++ b/backend/app/tests/test_metrics_recompute_endpoint.py
@@ -1,0 +1,169 @@
+# flake8: noqa
+import os
+import sys
+import uuid
+from pathlib import Path
+from datetime import date
+
+sys.path.append(str(Path(__file__).resolve().parents[3]))
+
+# Required environment variables
+os.environ["database_url"] = "sqlite:///./test.db"
+os.environ.setdefault("jwt_secret", "test")
+os.environ.setdefault("openai_api_key", "test")
+os.environ.setdefault("xero_client_id", "test")
+os.environ.setdefault("xero_client_secret", "test")
+os.environ.setdefault("xero_redirect_uri", "http://localhost")
+os.environ.setdefault("google_client_id", "test")
+os.environ.setdefault("google_client_secret", "test")
+os.environ.setdefault("google_redirect_uri", "http://localhost")
+os.environ.setdefault("secret_key", "test")
+
+from fastapi.testclient import TestClient
+from jose import jwt
+
+from backend.app.main import app
+from backend.app.database import Base, engine, SessionLocal
+from backend.app.models import (
+    User,
+    Project,
+    FundingResource,
+    Beneficiary,
+    Outcome,
+    ProjectSummary,
+    MonthlyRollup,
+    MetricsSummary,
+)
+from backend.app.api import deps as deps_module
+from backend.app.routes.metrics import recompute as recompute_route
+
+
+def setup_function(_):
+    db_path = Path("test.db")
+    if db_path.exists():
+        db_path.unlink()
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    db = SessionLocal()
+    user = User(id=1, email="user@example.com", hashed_password="x", name="Test")
+    db.add(user)
+    project_id = "p1"
+    db.add(
+        Project(
+            id=project_id,
+            owner_org_id="org1",
+            project_id="p1",
+            name="Project 1",
+            source_system="excel",
+            schema_version=1,
+        )
+    )
+    db.add(
+        FundingResource(
+            id=str(uuid.uuid4()),
+            project_fk=project_id,
+            date=date(2024, 4, 1),
+            funding_source="donor",
+            received=100.0,
+            spent=80.0,
+            volunteer_hours=0,
+            staff_hours=0,
+            source_system="excel",
+            schema_version=1,
+        )
+    )
+    db.add(
+        Beneficiary(
+            id=str(uuid.uuid4()),
+            project_fk=project_id,
+            date=date(2024, 5, 1),
+            group="g1",
+            count=20,
+            demographic_info="info",
+            location="loc",
+            notes="b",
+            source_system="excel",
+            schema_version=1,
+        )
+    )
+    db.add(
+        Outcome(
+            id=str(uuid.uuid4()),
+            project_fk=project_id,
+            date=date(2024, 3, 1),
+            outcome_metric="metric",
+            value=5.0,
+            unit="u",
+            method="m",
+            notes="o",
+            source_system="excel",
+            schema_version=1,
+        )
+    )
+    db.commit()
+    db.close()
+
+
+client = TestClient(app)
+
+
+def _fake_verify_token(token: str):
+    try:
+        return jwt.decode(token, os.environ["jwt_secret"], algorithms=["HS256"])
+    except Exception:
+        return None
+
+
+deps_module.verify_token = _fake_verify_token
+recompute_route.verify_token = _fake_verify_token
+
+
+def make_token(org_id="org1", roles=None):
+    payload = {"sub": "1", "type": "access", "org_id": org_id}
+    if roles:
+        payload["roles"] = roles
+    return jwt.encode(payload, os.environ["jwt_secret"], algorithm="HS256")
+
+
+def test_recompute_requires_admin_for_org():
+    token = make_token()
+    response = client.post(
+        "/metrics:recompute",
+        json={},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert response.status_code == 403
+
+
+def test_recompute_metrics_org_admin():
+    token = make_token(roles=["admin"])
+    response = client.post(
+        "/metrics:recompute",
+        json={},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert response.status_code == 200
+    counts = response.json()
+    assert counts == {
+        "projects": 1,
+        "project_summaries": 1,
+        "monthly_rollups": 2,
+        "metrics_summary": 1,
+    }
+    db = SessionLocal()
+    ms = db.query(MetricsSummary).filter_by(project_fk="p1", metric_name="metric").one()
+    assert ms.total_value == 5.0
+    db.close()
+
+
+def test_recompute_metrics_project_owner():
+    token = make_token()
+    response = client.post(
+        "/metrics:recompute",
+        json={"project_id": "p1"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert response.status_code == 200
+    counts = response.json()
+    assert counts["projects"] == 1
+

--- a/backend/worker/tasks/ingest_excel_or_csv.py
+++ b/backend/worker/tasks/ingest_excel_or_csv.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from typing import Dict, Any
 
 from ..worker import app
+from .recompute_metrics import recompute_metrics
 
 
 @dataclass
@@ -71,6 +72,10 @@ def ingest_excel_or_csv(self, job_id: int) -> Dict[str, Any]:
             duration_ms=duration_ms,
             counts=counts.__dict__,
         )
+        try:
+            recompute_metrics.delay(org_id=str(job.org_id))
+        except Exception:
+            pass
         return {"status": "success", "duration_ms": duration_ms}
     except Exception as exc:  # pragma: no cover - exercised in tests
         db.rollback()

--- a/backend/worker/tasks/recompute_metrics.py
+++ b/backend/worker/tasks/recompute_metrics.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from ..worker import app
+
+
+def _close_db(db) -> None:
+    try:
+        db.close()
+    except Exception:
+        pass
+
+
+@app.task(bind=True)
+def recompute_metrics(self, org_id: str, project_id: str | None = None) -> Dict[str, int]:
+    """Recompute summary metrics for an organization or single project."""
+    from backend.app.database import SessionLocal
+    from backend.app.metrics.compute import recompute_for_project
+    from backend.app.models import (
+        Project,
+        ProjectSummary,
+        MonthlyRollup,
+        MetricsSummary,
+    )
+
+    db = SessionLocal()
+    try:
+        if project_id:
+            project_ids: List[str] = [project_id]
+        else:
+            project_ids = [
+                p.id for p in db.query(Project).filter(Project.owner_org_id == str(org_id)).all()
+            ]
+        totals = {
+            "projects": 0,
+            "project_summaries": 0,
+            "monthly_rollups": 0,
+            "metrics_summary": 0,
+        }
+        for pid in project_ids:
+            recompute_for_project(db, pid)
+            totals["projects"] += 1
+            totals["project_summaries"] += db.query(ProjectSummary).filter_by(project_fk=pid).count()
+            totals["monthly_rollups"] += db.query(MonthlyRollup).filter_by(project_fk=pid).count()
+            totals["metrics_summary"] += db.query(MetricsSummary).filter_by(project_fk=pid).count()
+        return totals
+    finally:
+        _close_db(db)

--- a/backend/worker/worker.py
+++ b/backend/worker/worker.py
@@ -49,4 +49,4 @@ def _on_worker_shutdown(**_):
     log_event("worker_shutdown", org_id=ORG_ID, project_id=PROJECT_ID)
 
 # Ensure tasks are registered
-from .tasks import ingest_excel_or_csv  # noqa: F401
+from .tasks import ingest_excel_or_csv, recompute_metrics  # noqa: F401


### PR DESCRIPTION
## Summary
- add Celery task to recompute metrics for a project or org
- trigger metrics recomputation after ingestion
- expose `/metrics:recompute` endpoint to manually refresh metrics with role checks

## Testing
- `pytest backend/app/tests/test_metrics_recompute_endpoint.py::test_recompute_metrics_org_admin -q`
- `pytest backend/app/tests/test_import_batches.py -q`
- `pytest backend/app/tests/test_ingestion_jobs_status.py -q`
- `pytest backend/app/tests/test_load_to_core.py -q`
- `pytest backend/app/tests/test_metrics_compute.py -q`
- `pytest backend/app/tests/test_template_download.py -q`
- `pytest backend/app/tests/test_upload_signed_url.py -q`
- `pytest backend/app/tests/test_mapping_loader.py -q`
- `pytest backend/app/tests/test_parse_and_stage.py -q`
- `pytest backend/app/tests/test_schema_validation.py -q`
- `pytest backend/app/tests/test_normalization.py -q`
- `pytest backend/app/tests/test_worker_boots.py -q` *(fails: FileNotFoundError: [Errno 2] No such file or directory: 'redis-server')*

------
https://chatgpt.com/codex/tasks/task_e_68ac4aaf27fc832ba53fd26b2e512739