### PR TITLE
Add Metabase service and setup docs

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -67,5 +67,28 @@ services:
       redis:
         condition: service_started
 
+  metabase:
+    image: metabase/metabase:latest
+    ports:
+      - "3000:3000"
+    env_file:
+      - .env            # ← make sure this points to your real .env
+    environment:
+      MB_SITE_URL: ${MB_SITE_URL}
+      MB_ENCRYPTION_SECRET: ${MB_ENCRYPTION_SECRET}
+      MB_DB_FILE: /metabase-data/metabase.db
+    volumes:
+      - metabase_data:/metabase-data
+    depends_on:
+      db:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3000/api/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+    restart: unless-stopped
+
 volumes:
   postgres_data:
+  metabase_data:

--- a/docs/metabase_setup.md
+++ b/docs/metabase_setup.md
@@ -1,0 +1,27 @@
+# Metabase Setup
+
+1. Add the following variables to `backend/.env`:
+
+   ```
+   MB_SITE_URL=http://localhost:3000
+   MB_ENCRYPTION_SECRET=change_me
+   ```
+
+2. Start the services:
+
+   ```
+   cd backend
+   docker compose up
+   ```
+
+3. Open [http://localhost:3000](http://localhost:3000) in your browser to complete Metabase's initial setup.
+
+4. When prompted to add your database, use these values:
+
+   - **Database type:** Postgres
+   - **Host:** db
+   - **Port:** 5432
+   - **Database name:** mega_x
+   - **Username:** postgres
+   - **Password:** password
+


### PR DESCRIPTION
## Summary
- add Metabase container with health check and persistent DB volume
- document how to configure Metabase and connect to Postgres

## Testing
- `docker compose config` *(fails: command not found: docker)*
- `bash scripts/lint.sh` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac4d529670832b873f3acae14de82d