### PR TITLE
Add PII redaction and beneficiary cleanup

### DIFF
--- a/backend/tests/test_cleanup_task.py
+++ b/backend/tests/test_cleanup_task.py
@@ -1,0 +1,58 @@
+import os
+import sys
+import pathlib
+from datetime import datetime, timedelta
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
+
+
+def test_cleanup_beneficiaries(monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "sqlite://")
+    monkeypatch.setenv("JWT_SECRET", "test")
+    monkeypatch.setenv("SECRET_KEY", "test")
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+    monkeypatch.setenv("XERO_CLIENT_ID", "test")
+    monkeypatch.setenv("XERO_CLIENT_SECRET", "test")
+    monkeypatch.setenv("XERO_REDIRECT_URI", "http://localhost")
+    monkeypatch.setenv("GOOGLE_CLIENT_ID", "test")
+    monkeypatch.setenv("GOOGLE_CLIENT_SECRET", "test")
+    monkeypatch.setenv("GOOGLE_REDIRECT_URI", "http://localhost")
+
+    from backend.app.database import Base
+    from backend.app.models.project import Project
+    from backend.app.models.beneficiary import Beneficiary
+
+    engine = create_engine("sqlite://")
+    TestingSession = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+    Base.metadata.create_all(bind=engine)
+    monkeypatch.setattr("backend.app.database.SessionLocal", TestingSession)
+
+    db = TestingSession()
+    old = datetime.utcnow() - timedelta(days=60)
+    recent = datetime.utcnow() - timedelta(days=10)
+
+    p1 = Project(id="p1", owner_org_id="org1", project_id="p1")
+    p2 = Project(id="p2", owner_org_id="org2", project_id="p2")
+    db.add_all([p1, p2])
+    db.commit()
+
+    b1 = Beneficiary(id="b1", project_fk="p1", ingested_at=old)
+    b2 = Beneficiary(id="b2", project_fk="p1", ingested_at=recent)
+    b3 = Beneficiary(id="b3", project_fk="p2", ingested_at=old)
+    db.add_all([b1, b2, b3])
+    db.commit()
+    db.close()
+
+    monkeypatch.setenv("BENEFICIARY_RETENTION_DAYS", "30")
+    from backend.worker.tasks.cleanup_beneficiaries import cleanup_beneficiaries
+
+    result = cleanup_beneficiaries()
+    assert result["org1"] == 1
+    assert result["org2"] == 1
+
+    db = TestingSession()
+    remaining = {b.id for b in db.query(Beneficiary.id).all()}
+    assert remaining == {"b2"}

--- a/backend/worker/tasks/cleanup_beneficiaries.py
+++ b/backend/worker/tasks/cleanup_beneficiaries.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import os
+from datetime import datetime, timedelta
+from typing import Dict
+
+from ..worker import app
+
+
+def _close_db(db) -> None:
+    try:
+        db.close()
+    except Exception:
+        pass
+
+
+@app.task(bind=True)
+def cleanup_beneficiaries(self) -> Dict[str, int]:
+    """Remove beneficiary rows older than retention window for each org."""
+    from backend.app.database import SessionLocal
+    from backend.app.models import Beneficiary, Project
+
+    retention_days = int(os.getenv("BENEFICIARY_RETENTION_DAYS", "365"))
+    cutoff = datetime.utcnow() - timedelta(days=retention_days)
+
+    db = SessionLocal()
+    try:
+        counts: Dict[str, int] = {}
+        org_ids = [row[0] for row in db.query(Project.owner_org_id).distinct()]
+        for org_id in org_ids:
+            proj_ids = (
+                db.query(Project.id)
+                .filter(Project.owner_org_id == org_id)
+                .subquery()
+            )
+            deleted = (
+                db.query(Beneficiary)
+                .filter(Beneficiary.project_fk.in_(proj_ids))
+                .filter(Beneficiary.ingested_at < cutoff)
+                .delete(synchronize_session=False)
+            )
+            counts[str(org_id)] = deleted
+        db.commit()
+        return counts
+    finally:
+        _close_db(db)


### PR DESCRIPTION
## Summary
- optionally redact email and phone numbers during ingestion
- schedule nightly cleanup of outdated beneficiaries based on retention policy
- test redaction toggle and cleanup task

## Testing
- `pytest` *(fails: ImportError and sqlite OperationalError)*
- `pytest tests/test_cleanup_task.py app/tests/test_normalization.py::test_pii_redaction`

------
https://chatgpt.com/codex/tasks/task_e_68ac56183828832b994b0e26e965b77c