### PR TITLE
Add compose stack with optional MinIO and env templates

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -1,0 +1,37 @@
+# Database
+POSTGRES_DB=mega_x
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=password
+DATABASE_URL=postgresql://postgres:password@db:5432/mega_x
+DATABASE_SSL_MODE=prefer
+
+# JWT/Auth
+JWT_SECRET=replace-with-long-random-hex
+JWT_ALGORITHM=HS256
+JWT_ACCESS_TOKEN_EXPIRE_MINUTES=30
+JWT_REFRESH_TOKEN_EXPIRE_DAYS=7
+SECRET_KEY=replace-with-another-long-random-string
+
+# Redis
+REDIS_URL=redis://redis:6379/0
+WORKER_CONCURRENCY=2
+
+# Metabase
+MB_SITE_URL=https://dev.example.com
+MB_ENCRYPTION_SECRET=changeme0123456789abcdef0123456789
+
+# Storage
+STORAGE_PROVIDER=minio
+S3_BUCKET=impactview
+S3_UPLOAD_PREFIX=raw/
+S3_REGION=us-east-1
+S3_ENDPOINT_URL=http://minio:9000
+
+# Optional integrations
+OPENAI_API_KEY=sk-test
+XERO_CLIENT_ID=your-xero-client-id
+XERO_CLIENT_SECRET=your-xero-client-secret
+XERO_REDIRECT_URI=http://localhost:8000/api/v1/integrations/xero/callback
+GOOGLE_CLIENT_ID=your-google-client-id
+GOOGLE_CLIENT_SECRET=your-google-client-secret
+GOOGLE_REDIRECT_URI=http://localhost:8000/api/v1/integrations/google/callback

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,37 @@
+# Database
+POSTGRES_DB=mega_x
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=password
+DATABASE_URL=postgresql://postgres:password@db:5432/mega_x
+DATABASE_SSL_MODE=prefer
+
+# JWT/Auth
+JWT_SECRET=replace-with-long-random-hex
+JWT_ALGORITHM=HS256
+JWT_ACCESS_TOKEN_EXPIRE_MINUTES=30
+JWT_REFRESH_TOKEN_EXPIRE_DAYS=7
+SECRET_KEY=replace-with-another-long-random-string
+
+# Redis
+REDIS_URL=redis://redis:6379/0
+WORKER_CONCURRENCY=2
+
+# Metabase
+MB_SITE_URL=http://localhost:3000
+MB_ENCRYPTION_SECRET=changeme0123456789abcdef0123456789
+
+# Storage
+STORAGE_PROVIDER=minio
+S3_BUCKET=impactview
+S3_UPLOAD_PREFIX=raw/
+S3_REGION=us-east-1
+S3_ENDPOINT_URL=http://minio:9000
+
+# Optional integrations
+OPENAI_API_KEY=sk-test
+XERO_CLIENT_ID=your-xero-client-id
+XERO_CLIENT_SECRET=your-xero-client-secret
+XERO_REDIRECT_URI=http://localhost:8000/api/v1/integrations/xero/callback
+GOOGLE_CLIENT_ID=your-google-client-id
+GOOGLE_CLIENT_SECRET=your-google-client-secret
+GOOGLE_REDIRECT_URI=http://localhost:8000/api/v1/integrations/google/callback

--- a/.env.local
+++ b/.env.local
@@ -1,0 +1,37 @@
+# Database
+POSTGRES_DB=mega_x
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=password
+DATABASE_URL=postgresql://postgres:password@db:5432/mega_x
+DATABASE_SSL_MODE=prefer
+
+# JWT/Auth
+JWT_SECRET=replace-with-long-random-hex
+JWT_ALGORITHM=HS256
+JWT_ACCESS_TOKEN_EXPIRE_MINUTES=30
+JWT_REFRESH_TOKEN_EXPIRE_DAYS=7
+SECRET_KEY=replace-with-another-long-random-string
+
+# Redis
+REDIS_URL=redis://redis:6379/0
+WORKER_CONCURRENCY=2
+
+# Metabase
+MB_SITE_URL=http://localhost:3000
+MB_ENCRYPTION_SECRET=changeme0123456789abcdef0123456789
+
+# Storage
+STORAGE_PROVIDER=minio
+S3_BUCKET=impactview
+S3_UPLOAD_PREFIX=raw/
+S3_REGION=us-east-1
+S3_ENDPOINT_URL=http://minio:9000
+
+# Optional integrations
+OPENAI_API_KEY=sk-test
+XERO_CLIENT_ID=your-xero-client-id
+XERO_CLIENT_SECRET=your-xero-client-secret
+XERO_REDIRECT_URI=http://localhost:8000/api/v1/integrations/xero/callback
+GOOGLE_CLIENT_ID=your-google-client-id
+GOOGLE_CLIENT_SECRET=your-google-client-secret
+GOOGLE_REDIRECT_URI=http://localhost:8000/api/v1/integrations/google/callback

--- a/.env.staging
+++ b/.env.staging
@@ -1,0 +1,37 @@
+# Database
+POSTGRES_DB=mega_x
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=password
+DATABASE_URL=postgresql://postgres:password@db:5432/mega_x
+DATABASE_SSL_MODE=prefer
+
+# JWT/Auth
+JWT_SECRET=replace-with-long-random-hex
+JWT_ALGORITHM=HS256
+JWT_ACCESS_TOKEN_EXPIRE_MINUTES=30
+JWT_REFRESH_TOKEN_EXPIRE_DAYS=7
+SECRET_KEY=replace-with-another-long-random-string
+
+# Redis
+REDIS_URL=redis://redis:6379/0
+WORKER_CONCURRENCY=2
+
+# Metabase
+MB_SITE_URL=https://staging.example.com
+MB_ENCRYPTION_SECRET=changeme0123456789abcdef0123456789
+
+# Storage
+STORAGE_PROVIDER=minio
+S3_BUCKET=impactview
+S3_UPLOAD_PREFIX=raw/
+S3_REGION=us-east-1
+S3_ENDPOINT_URL=http://minio:9000
+
+# Optional integrations
+OPENAI_API_KEY=sk-test
+XERO_CLIENT_ID=your-xero-client-id
+XERO_CLIENT_SECRET=your-xero-client-secret
+XERO_REDIRECT_URI=http://localhost:8000/api/v1/integrations/xero/callback
+GOOGLE_CLIENT_ID=your-google-client-id
+GOOGLE_CLIENT_SECRET=your-google-client-secret
+GOOGLE_REDIRECT_URI=http://localhost:8000/api/v1/integrations/google/callback

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,10 @@ venv/
 # Environment variables
 .env
 .env.*
+!.env.example
+!.env.local
+!.env.dev
+!.env.staging
 
 # VS Code
 .vscode/

--- a/docker-compose.minio.yml
+++ b/docker-compose.minio.yml
@@ -1,0 +1,23 @@
+version: '3.8'
+
+services:
+  minio:
+    image: minio/minio:latest
+    command: server /data --console-address ":9001"
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
+    volumes:
+      - minio_data:/data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/ready"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+    restart: unless-stopped
+
+volumes:
+  minio_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,107 @@
+version: '3.8'
+
+services:
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_DB: mega_x
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: password
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d mega_x || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 15
+    restart: unless-stopped
+
+  redis:
+    image: redis:7
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+  backend:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./backend:/app
+    env_file:
+      - .env.local
+    environment:
+      ALGORITHM: ${JWT_ALGORITHM:-HS256}
+      ACCESS_TOKEN_EXPIRE_MINUTES: ${JWT_ACCESS_TOKEN_EXPIRE_MINUTES:-30}
+      REFRESH_TOKEN_EXPIRE_MINUTES: ${REFRESH_TOKEN_EXPIRE_MINUTES:-10080}
+      PYTHONUNBUFFERED: "1"
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+    restart: unless-stopped
+
+  worker:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    command: celery -A worker.worker worker --loglevel=info --concurrency=${WORKER_CONCURRENCY:-2}
+    volumes:
+      - ./backend:/app
+    env_file:
+      - .env.local
+    environment:
+      REDIS_URL: ${REDIS_URL:-redis://redis:6379/0}
+      WORKER_CONCURRENCY: ${WORKER_CONCURRENCY:-2}
+      PYTHONUNBUFFERED: "1"
+    depends_on:
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "celery -A worker.worker inspect ping -d celery@$$HOSTNAME"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+    restart: unless-stopped
+
+  metabase:
+    image: metabase/metabase:latest
+    ports:
+      - "3000:3000"
+    env_file:
+      - .env.local
+    environment:
+      MB_SITE_URL: ${MB_SITE_URL}
+      MB_ENCRYPTION_SECRET: ${MB_ENCRYPTION_SECRET}
+      MB_DB_FILE: /metabase-data/metabase.db
+    volumes:
+      - metabase_data:/metabase-data
+    depends_on:
+      db:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3000/api/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+    restart: unless-stopped
+
+volumes:
+  postgres_data:
+  metabase_data:


### PR DESCRIPTION
## Summary
- Add root docker-compose stack for API, Postgres, Redis, worker, and Metabase
- Provide optional MinIO service override and healthchecks
- Include example env files and allow them in `.gitignore`

## Testing
- `docker compose config` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed/403)*

------
https://chatgpt.com/codex/tasks/task_e_68ac57a269c0832b8f73b8d25ecd7236