### PR TITLE
feat: add ingest upload UI with error handling

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,6 +18,7 @@ import Investors from "./pages/Investors";
 import Settings from "./pages/Settings";
 import NotFound from "./pages/NotFound";
 import ImpactSummary from "./pages/dashboards/ImpactSummary";
+import UploadPage from "./pages/ingest/UploadPage";
 
 const queryClient = new QueryClient();
 
@@ -47,6 +48,7 @@ const App = () => (
               <Route path="investors" element={<Investors />} />
               <Route path="settings" element={<Settings />} />
               <Route path="dashboards/impact-summary" element={<ImpactSummary />} />
+              <Route path="ingest/upload" element={<UploadPage />} />
             </Route>
             
             {/* Catch-all route */}

--- a/frontend/src/components/ingest/UploadWidget.tsx
+++ b/frontend/src/components/ingest/UploadWidget.tsx
@@ -1,0 +1,145 @@
+import React, { useState, useEffect } from "react";
+import { Input } from "@/components/ui/input";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Upload as UploadIcon } from "lucide-react";
+import { toast } from "@/hooks/use-toast";
+import { api } from "@/lib/api";
+
+interface JobStatus {
+  status: string;
+  error?: any;
+}
+
+const POLL_INTERVAL_MS = 2000;
+
+const UploadWidget: React.FC = () => {
+  const [isUploading, setIsUploading] = useState(false);
+  const [sheetErrors, setSheetErrors] = useState<Record<string, string[]>>({});
+  const [jobId, setJobId] = useState<number | null>(null);
+
+  useEffect(() => {
+    let timer: ReturnType<typeof setInterval> | null = null;
+    if (jobId !== null) {
+      timer = setInterval(async () => {
+        try {
+          const res = await api.get<JobStatus>(`/ingest/jobs/${jobId}`);
+          if (res.data.status === "success") {
+            clearInterval(timer!);
+            toast({ title: "Ingestion complete", description: "File processed successfully" });
+            setJobId(null);
+          } else if (res.data.status === "failed") {
+            clearInterval(timer!);
+            const err = res.data.error;
+            const parsed: Record<string, string[]> = {};
+            if (err) {
+              let detail: any = err;
+              if (typeof err.error === "string") {
+                try {
+                  detail = JSON.parse(err.error);
+                } catch {
+                  detail = err;
+                }
+              }
+              if (detail.sheet && Array.isArray(detail.missing)) {
+                parsed[detail.sheet] = detail.missing;
+              } else if (detail.sheet && detail.error) {
+                parsed[detail.sheet] = [String(detail.error)];
+              } else if (detail.error) {
+                parsed["General"] = [String(detail.error)];
+              }
+            }
+            setSheetErrors(parsed);
+            toast({
+              title: "Ingestion failed",
+              description: "See errors below",
+              variant: "destructive",
+            });
+            setJobId(null);
+          }
+        } catch (pollErr) {
+          console.error(pollErr);
+          clearInterval(timer!);
+          setJobId(null);
+        }
+      }, POLL_INTERVAL_MS);
+    }
+    return () => {
+      if (timer) clearInterval(timer);
+    };
+  }, [jobId]);
+
+  const handleFileUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    setIsUploading(true);
+    setSheetErrors({});
+    try {
+      const signed = await api.post(
+        "/ingest/uploads:signed-url",
+        {
+          filename: file.name,
+          mime: file.type,
+          size: file.size,
+        }
+      );
+      const { url, fields, upload_id } = signed.data;
+      const form = new FormData();
+      Object.entries(fields).forEach(([k, v]) => form.append(k, v as string));
+      form.append("file", file);
+      await fetch(url, { method: "POST", body: form });
+
+      const jobRes = await api.post("/ingest/jobs", { upload_id });
+      setJobId(jobRes.data.job_id);
+      toast({ title: "File uploaded", description: "Processing has started" });
+    } catch (err) {
+      console.error(err);
+      toast({
+        title: "Upload failed",
+        description: "Could not upload file",
+        variant: "destructive",
+      });
+    } finally {
+      setIsUploading(false);
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center space-x-2">
+          <UploadIcon className="h-5 w-5" />
+          <span>Upload Data</span>
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-4">
+          <Input
+            type="file"
+            accept=".xlsx,.csv"
+            onChange={handleFileUpload}
+            disabled={isUploading}
+          />
+          {isUploading && <p className="text-sm text-gray-500">Uploading...</p>}
+          {Object.keys(sheetErrors).length > 0 && (
+            <div className="space-y-4">
+              {Object.entries(sheetErrors).map(([sheet, errors]) => (
+                <div key={sheet}>
+                  <h4 className="font-medium">{sheet}</h4>
+                  <ul className="list-disc pl-5 text-sm text-red-600">
+                    {errors.map((err, idx) => (
+                      <li key={idx}>{err}</li>
+                    ))}
+                  </ul>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default UploadWidget;
+

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,5 @@
 import axios from "axios";
+import { toast } from "@/hooks/use-toast";
 
 // All requests go to /api, which Vite proxies to your backend /api/v1
 export const api = axios.create({
@@ -12,3 +13,26 @@ api.interceptors.request.use(cfg => {
   if (accessToken) cfg.headers.Authorization = `Bearer ${accessToken}`;
   return cfg;
 });
+
+api.interceptors.response.use(
+  res => res,
+  err => {
+    const detail = err?.response?.data?.detail;
+    let message = "An unexpected error occurred";
+    if (detail) {
+      if (typeof detail === "string") {
+        message = detail;
+      } else if (detail.sheet && Array.isArray(detail.missing)) {
+        message = `Sheet "${detail.sheet}" is missing required columns: ${detail.missing.join(", ")}`;
+      }
+    } else if (err.message) {
+      message = err.message;
+    }
+    toast({
+      title: "Request failed",
+      description: message,
+      variant: "destructive",
+    });
+    return Promise.reject(err);
+  }
+);

--- a/frontend/src/pages/ingest/UploadPage.tsx
+++ b/frontend/src/pages/ingest/UploadPage.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import UploadWidget from "@/components/ingest/UploadWidget";
+
+const UploadPage: React.FC = () => (
+  <div className="space-y-6">
+    <h1 className="text-3xl font-bold text-gray-900">Ingest Upload</h1>
+    <UploadWidget />
+  </div>
+);
+
+export default UploadPage;
+


### PR DESCRIPTION
## Summary
- add ingest upload widget and page
- add axios interceptor to surface API errors via toast notifications
- register ingest upload route

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'jinja2'; sqlite3.OperationalError: attempt to write a readonly database)*
- `cd frontend && bun test`

------
https://chatgpt.com/codex/tasks/task_e_68ac5b9dc730832bbe4383ac39cf6a37