### PR TITLE
feat: add excel upload backend

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -14,6 +14,7 @@ from .api.routes import (
 from .routes.public.template import router as public_template_router
 from .routes.ingest.upload import router as ingest_upload_router
 from .routes.ingest.jobs import router as ingest_jobs_router
+from .routes.uploads import router as uploads_router
 from .routes.metrics.recompute import router as metrics_recompute_router
 from .routes.dashboards.embed import router as dashboards_embed_router
 from .routes.reports import router as reports_generate_router
@@ -45,6 +46,7 @@ app.include_router(investors_router, prefix="/api/v1")
 app.include_router(public_template_router)
 app.include_router(ingest_upload_router)
 app.include_router(ingest_jobs_router)
+app.include_router(uploads_router)
 app.include_router(metrics_recompute_router)
 app.include_router(dashboards_embed_router)
 app.include_router(reports_generate_router)

--- a/backend/app/models/uploads.py
+++ b/backend/app/models/uploads.py
@@ -7,6 +7,7 @@ from sqlalchemy import (
     ForeignKey,
     Enum,
     BigInteger,
+    JSON,
 )
 from sqlalchemy.sql import func
 from sqlalchemy.orm import relationship
@@ -16,9 +17,12 @@ from .user import User
 
 
 class UploadStatus(str, enum.Enum):
+    """Lifecycle states for an uploaded workbook."""
+
     pending = "pending"
-    completed = "completed"
+    validated = "validated"
     failed = "failed"
+    ingested = "ingested"
 
 
 class Upload(Base):
@@ -36,6 +40,9 @@ class Upload(Base):
         default=UploadStatus.pending,
         nullable=False,
     )
+    template_version = Column(String, nullable=False, default="v1")
+    errors_json = Column(JSON, nullable=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())
 
     user = relationship("User")

--- a/backend/app/routes/ingest/jobs.py
+++ b/backend/app/routes/ingest/jobs.py
@@ -13,7 +13,7 @@ from ...models.ingestion_jobs import IngestionJob, IngestionJobStatus
 from ...models.import_batches import ImportBatch, BatchStatus
 from ...observability.events import log_event
 from ...audit.logger import log_event as log_audit_event
-from worker.tasks.ingest_excel_or_csv import ingest_excel_or_csv
+from ....worker.tasks.ingest_excel_or_csv import ingest_excel_or_csv
 
 router = APIRouter(prefix="/ingest", tags=["ingest"])
 

--- a/backend/app/routes/metrics/recompute.py
+++ b/backend/app/routes/metrics/recompute.py
@@ -8,7 +8,7 @@ from ...auth import require_roles, Role
 from ...database import get_db
 from ...models.user import User
 from ...models.project import Project
-from worker.tasks.recompute_metrics import recompute_metrics as recompute_metrics_task
+from ....worker.tasks.recompute_metrics import recompute_metrics as recompute_metrics_task
 from ...audit.logger import log_event
 
 router = APIRouter(tags=["metrics"])

--- a/backend/app/routes/uploads.py
+++ b/backend/app/routes/uploads.py
@@ -1,0 +1,181 @@
+import os
+from uuid import uuid4
+from typing import Optional
+
+from fastapi import APIRouter, UploadFile, File, Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials
+from sqlalchemy.orm import Session
+
+from ..api.deps import verify_token, security
+from ..auth import require_roles, Role
+from ..database import get_db
+from ..models.user import User
+from ..models.uploads import Upload, UploadStatus
+from ..models.ingestion_jobs import IngestionJob, IngestionJobStatus
+from ..models.import_batches import ImportBatch, BatchStatus
+from ..storage.s3_client import get_s3_client
+from ..ingest.validators import validate_template_excel, TEMPLATE_VERSION
+from ..schemas.upload import UploadCreateResponse, UploadStatusResponse
+from ...worker.tasks.ingest_excel_or_csv import ingest_excel_or_csv
+
+router = APIRouter(prefix="/api/uploads", tags=["uploads"])
+
+FILE_MAX_MB = int(os.getenv("FILE_MAX_MB", "5"))
+FILE_MAX_BYTES = FILE_MAX_MB * 1024 * 1024
+
+
+@router.post("", status_code=201, response_model=UploadCreateResponse)
+async def create_upload(
+    file: UploadFile = File(...),
+    current_user: User = Depends(require_roles([Role.org_member, Role.admin])),
+    creds: HTTPAuthorizationCredentials = Depends(security),
+    db: Session = Depends(get_db),
+):
+    if not file.filename.lower().endswith(".xlsx"):
+        raise HTTPException(status_code=400, detail="Only .xlsx files are supported")
+
+    contents = await file.read()
+    if len(contents) > FILE_MAX_BYTES:
+        raise HTTPException(status_code=400, detail="File too large")
+
+    payload = verify_token(creds.credentials)
+    org_id: Optional[int] = payload.get("org_id") if payload else None
+    if org_id is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
+
+    upload = Upload(
+        org_id=org_id,
+        user_id=current_user.id,
+        filename=file.filename,
+        mime_type=file.content_type,
+        size=len(contents),
+        object_key="",
+        status=UploadStatus.pending,
+        template_version=TEMPLATE_VERSION,
+    )
+    db.add(upload)
+    db.commit()
+    db.refresh(upload)
+
+    prefix = os.getenv("S3_UPLOAD_PREFIX", "uploads/")
+    key = f"{prefix}{current_user.id}/{uuid4()}.xlsx"
+    upload.object_key = key
+    db.commit()
+
+    bucket = os.environ["S3_BUCKET"]
+    s3 = get_s3_client()
+    s3.put_object(Bucket=bucket, Key=key, Body=contents, ContentType=file.content_type)
+
+    return {"upload_id": upload.id}
+
+
+@router.get("/{upload_id}", response_model=UploadStatusResponse)
+async def get_upload(
+    upload_id: int,
+    current_user: User = Depends(require_roles([Role.org_member, Role.admin])),
+    creds: HTTPAuthorizationCredentials = Depends(security),
+    db: Session = Depends(get_db),
+):
+    payload = verify_token(creds.credentials)
+    org_id = payload.get("org_id") if payload else None
+    if org_id is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
+
+    upload = (
+        db.query(Upload)
+        .filter(Upload.id == upload_id, Upload.org_id == org_id)
+        .first()
+    )
+    if upload is None:
+        raise HTTPException(status_code=404, detail="Upload not found")
+
+    return {
+        "status": upload.status.value,
+        "template_version": upload.template_version,
+        "errors": upload.errors_json,
+    }
+
+
+@router.post("/{upload_id}/validate", response_model=UploadStatusResponse)
+async def validate_upload(
+    upload_id: int,
+    current_user: User = Depends(require_roles([Role.org_member, Role.admin])),
+    creds: HTTPAuthorizationCredentials = Depends(security),
+    db: Session = Depends(get_db),
+):
+    payload = verify_token(creds.credentials)
+    org_id = payload.get("org_id") if payload else None
+    if org_id is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
+
+    upload = (
+        db.query(Upload)
+        .filter(Upload.id == upload_id, Upload.org_id == org_id)
+        .first()
+    )
+    if upload is None:
+        raise HTTPException(status_code=404, detail="Upload not found")
+
+    bucket = os.environ["S3_BUCKET"]
+    s3 = get_s3_client()
+    obj = s3.get_object(Bucket=bucket, Key=upload.object_key)
+    content = obj["Body"].read()
+
+    errors = validate_template_excel(content)
+    if errors:
+        upload.status = UploadStatus.failed
+        upload.errors_json = errors
+    else:
+        upload.status = UploadStatus.validated
+        upload.errors_json = None
+    db.commit()
+
+    return {
+        "status": upload.status.value,
+        "template_version": upload.template_version,
+        "errors": upload.errors_json,
+    }
+
+
+@router.post("/{upload_id}/ingest", status_code=202)
+async def ingest_upload(
+    upload_id: int,
+    current_user: User = Depends(require_roles([Role.org_member, Role.admin])),
+    creds: HTTPAuthorizationCredentials = Depends(security),
+    db: Session = Depends(get_db),
+):
+    payload = verify_token(creds.credentials)
+    org_id = payload.get("org_id") if payload else None
+    if org_id is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
+
+    upload = (
+        db.query(Upload)
+        .filter(Upload.id == upload_id, Upload.org_id == org_id)
+        .first()
+    )
+    if upload is None:
+        raise HTTPException(status_code=404, detail="Upload not found")
+
+    batch = ImportBatch(
+        id=str(uuid4()),
+        source_system="upload",
+        triggered_by_user_id=str(current_user.id),
+        status=BatchStatus.queued,
+    )
+    db.add(batch)
+    db.flush()
+
+    job = IngestionJob(
+        org_id=org_id,
+        upload_id=upload.id,
+        import_batch_id=batch.id,
+        status=IngestionJobStatus.queued,
+    )
+    db.add(job)
+    db.commit()
+    db.refresh(job)
+
+    ingest_excel_or_csv.delay(job.id)
+
+    return {"job_id": job.id}

--- a/backend/app/schemas/upload.py
+++ b/backend/app/schemas/upload.py
@@ -12,3 +12,13 @@ class SignedUrlResponse(BaseModel):
     url: str
     fields: Dict[str, str]
     upload_id: int
+
+
+class UploadCreateResponse(BaseModel):
+    upload_id: int
+
+
+class UploadStatusResponse(BaseModel):
+    status: str
+    template_version: str
+    errors: list | None = None

--- a/backend/app/tests/test_excel_validator.py
+++ b/backend/app/tests/test_excel_validator.py
@@ -1,0 +1,72 @@
+from io import BytesIO
+from pathlib import Path
+import os
+import sys
+
+import pandas as pd
+import pytest
+
+# Configure environment for importing
+sys.path.append(str(Path(__file__).resolve().parents[3]))
+os.environ.setdefault("database_url", "sqlite://")
+os.environ.setdefault("jwt_secret", "test")
+os.environ.setdefault("secret_key", "test")
+
+from backend.app.ingest.validators import (
+    TEMPLATE_SHEETS,
+    validate_template_excel,
+)
+
+
+def _build_excel(sheets):
+    buf = BytesIO()
+    with pd.ExcelWriter(buf, engine="openpyxl") as writer:
+        for name, df in sheets.items():
+            df.to_excel(writer, sheet_name=name, index=False)
+    buf.seek(0)
+    return buf.getvalue()
+
+
+def test_validator_missing_sheet_and_column():
+    # Build workbook missing the 'Activities' sheet and a column in 'Project Info'
+    sheets = {}
+    for name, cols in TEMPLATE_SHEETS.items():
+        if name == "Activities":
+            continue
+        df_cols = list(cols.keys())
+        if name == "Project Info":
+            df_cols = df_cols[:-1]  # drop last column
+        df = pd.DataFrame(columns=df_cols)
+        sheets[name] = df
+    content = _build_excel(sheets)
+    errors = validate_template_excel(content)
+    assert {"sheet": "Activities", "column": None, "issue": "missing_sheet"} in errors
+    assert {
+        "sheet": "Project Info",
+        "column": list(TEMPLATE_SHEETS["Project Info"].keys())[-1],
+        "issue": "missing_column",
+    } in errors
+
+
+def test_validator_wrong_dtype():
+    # Build workbook with incorrect dtype for Beneficiaries.Count (should be int)
+    sheets = {}
+    for name, cols in TEMPLATE_SHEETS.items():
+        df_cols = list(cols.keys())
+        df = pd.DataFrame(columns=df_cols)
+        if name == "Beneficiaries":
+            df = pd.DataFrame(
+                {
+                    "Project ID": [1],
+                    "Date": ["2025-06"],
+                    "Beneficiary Group": ["A"],
+                    "Count": ["not-int"],
+                    "Demographic Info": ["x"],
+                    "Location": ["x"],
+                    "Notes": ["x"],
+                }
+            )
+        sheets[name] = df
+    content = _build_excel(sheets)
+    errors = validate_template_excel(content)
+    assert {"sheet": "Beneficiaries", "column": "Count", "issue": "invalid_type"} in errors

--- a/backend/app/tests/test_ingestion_jobs_status.py
+++ b/backend/app/tests/test_ingestion_jobs_status.py
@@ -54,19 +54,24 @@ Base.metadata.create_all(bind=engine)
 
 # Seed user and upload
 _db = SessionLocal()
-user = User(id=2, email="user2@example.com", hashed_password="x", name="Test2")
+user = User(email="user3@example.com", hashed_password="x", name="Test2")
+_db.add(user)
+_db.commit()
+_db.refresh(user)
+user_id = user.id
 upload = Upload(
     org_id=123,
-    user_id=2,
+    user_id=user_id,
     filename="data.csv",
     mime_type="text/csv",
     size=100,
     object_key="obj",
-    status=UploadStatus.completed,
+    status=UploadStatus.validated,
 )
-_db.add_all([user, upload])
+_db.add(upload)
 _db.commit()
 _db.close()
+USER_ID = user_id
 
 
 def _fake_verify_token(token: str):
@@ -83,7 +88,7 @@ client = TestClient(app)
 
 
 def make_token(org_id=123, roles=None):
-    payload = {"sub": "2", "type": "access", "org_id": org_id}
+    payload = {"sub": str(USER_ID), "type": "access", "org_id": org_id}
     if roles:
         payload["roles"] = roles
     return jwt.encode(payload, os.environ["jwt_secret"], algorithm="HS256")

--- a/backend/app/tests/test_upload_signed_url.py
+++ b/backend/app/tests/test_upload_signed_url.py
@@ -51,9 +51,11 @@ if db_path.exists():
 Base.metadata.create_all(bind=engine)
 
 db = SessionLocal()
-user = User(id=1, email="user@example.com", hashed_password="x", name="Test")
+user = User(email="signed@example.com", hashed_password="x", name="Test")
 db.add(user)
 db.commit()
+db.refresh(user)
+USER_ID = user.id
 db.close()
 
 
@@ -71,7 +73,7 @@ client = TestClient(app)
 
 
 def make_token(roles=None):
-    payload = {"sub": "1", "type": "access", "org_id": 123}
+    payload = {"sub": str(USER_ID), "type": "access", "org_id": 123}
     if roles:
         payload["roles"] = roles
     return jwt.encode(payload, os.environ["jwt_secret"], algorithm="HS256")
@@ -101,7 +103,7 @@ def test_signed_url_xlsx():
     assert upload.status == UploadStatus.pending
     assert upload.mime_type == body["mime"]
     assert upload.size == body["size"]
-    assert upload.user_id == 1
+    assert upload.user_id == USER_ID
     db.close()
 
 

--- a/backend/app/tests/test_uploads_api.py
+++ b/backend/app/tests/test_uploads_api.py
@@ -1,0 +1,156 @@
+from io import BytesIO
+from pathlib import Path
+import os
+import sys
+
+BASE_DIR = Path(__file__).resolve().parents[2]
+sys.path.append(str(BASE_DIR))
+sys.path.append(str(BASE_DIR.parent))
+from jose import jwt
+import pandas as pd
+from fastapi.testclient import TestClient
+
+# Setup environment
+os.environ.setdefault("database_url", "sqlite:///./uploads_api.db")
+os.environ.setdefault("jwt_secret", "test")
+os.environ.setdefault("secret_key", "test")
+os.environ.setdefault("openai_api_key", "test")
+os.environ.setdefault("xero_client_id", "test")
+os.environ.setdefault("xero_client_secret", "test")
+os.environ.setdefault("xero_redirect_uri", "http://localhost")
+os.environ.setdefault("google_client_id", "test")
+os.environ.setdefault("google_client_secret", "test")
+os.environ.setdefault("google_redirect_uri", "http://localhost")
+os.environ.setdefault("STORAGE_PROVIDER", "s3")
+os.environ.setdefault("S3_BUCKET", "test-bucket")
+os.environ.setdefault("S3_UPLOAD_PREFIX", "uploads/")
+os.environ.setdefault("AUTH0_DOMAIN", "test")
+
+from backend.app.main import app
+from backend.app.database import Base, engine, SessionLocal
+from backend.app.models.user import User
+from backend.app.routes import uploads as uploads_route
+from backend.app.ingest.validators import TEMPLATE_SHEETS
+from backend.worker.tasks.ingest_excel_or_csv import ingest_excel_or_csv
+from backend.app.api import deps as deps_module
+object.__setattr__(deps_module.settings, "auth0_domain", "test")
+object.__setattr__(deps_module.settings, "auth0_audience", "test")
+def _fake_verify_token(token: str):
+    try:
+        return jwt.decode(token, os.environ["jwt_secret"], algorithms=["HS256"])
+    except Exception:
+        return None
+deps_module.verify_token = _fake_verify_token
+uploads_route.verify_token = _fake_verify_token
+
+# Prepare database
+_db_path = Path("uploads_api.db")
+if _db_path.exists():
+    _db_path.unlink()
+Base.metadata.create_all(bind=engine)
+_db = SessionLocal()
+user = User(email="uploads@example.com", hashed_password="x", name="T")
+_db.add(user)
+_db.commit()
+_db.refresh(user)
+USER_ID = user.id
+_db.close()
+
+# Dummy S3 client
+class DummyS3:
+    def __init__(self):
+        self.store = {}
+
+    def put_object(self, Bucket, Key, Body, ContentType):
+        self.store[Key] = Body
+
+    def get_object(self, Bucket, Key):
+        return {"Body": BytesIO(self.store[Key])}
+
+dummy_s3 = DummyS3()
+uploads_route.get_s3_client = lambda: dummy_s3
+
+# Stub celery task
+class DummyAsyncResult:
+    def __init__(self, id):
+        self.id = id
+
+def _fake_delay(job_id):
+    return DummyAsyncResult(job_id)
+
+ingest_excel_or_csv.delay = _fake_delay
+
+client = TestClient(app)
+
+
+def make_token():
+    payload = {"sub": str(USER_ID), "type": "access", "org_id": 123, "roles": ["org_member"]}
+    return jwt.encode(payload, os.environ["jwt_secret"], algorithm="HS256")
+
+
+def _build_valid_workbook():
+    sheets = {}
+    for name, cols in TEMPLATE_SHEETS.items():
+        data = {}
+        for col, typ in cols.items():
+            if typ is int:
+                data[col] = [1]
+            elif typ is float:
+                data[col] = [1.0]
+            else:
+                data[col] = ["x"]
+        sheets[name] = pd.DataFrame(data)
+    buf = BytesIO()
+    with pd.ExcelWriter(buf, engine="openpyxl") as writer:
+        for name, df in sheets.items():
+            df.to_excel(writer, sheet_name=name, index=False)
+    buf.seek(0)
+    return buf.getvalue()
+
+
+def _build_invalid_workbook():
+    # Missing the 'Funding & Resources' sheet
+    sheets = {}
+    for name, cols in TEMPLATE_SHEETS.items():
+        if name == "Funding & Resources":
+            continue
+        sheets[name] = pd.DataFrame({c: [] for c in cols.keys()})
+    buf = BytesIO()
+    with pd.ExcelWriter(buf, engine="openpyxl") as writer:
+        for name, df in sheets.items():
+            df.to_excel(writer, sheet_name=name, index=False)
+    buf.seek(0)
+    return buf.getvalue()
+
+
+def test_upload_validate_ingest_flow():
+    token = make_token()
+    files = {"file": ("data.xlsx", _build_valid_workbook(), "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")}
+    res = client.post("/api/uploads", files=files, headers={"Authorization": f"Bearer {token}"})
+    assert res.status_code == 201
+    upload_id = res.json()["upload_id"]
+
+    res = client.post(f"/api/uploads/{upload_id}/validate", headers={"Authorization": f"Bearer {token}"})
+    assert res.status_code == 200
+    assert res.json()["status"] == "validated"
+
+    res = client.get(f"/api/uploads/{upload_id}", headers={"Authorization": f"Bearer {token}"})
+    assert res.status_code == 200
+    assert res.json()["status"] == "validated"
+
+    res = client.post(f"/api/uploads/{upload_id}/ingest", headers={"Authorization": f"Bearer {token}"})
+    assert res.status_code == 202
+    assert "job_id" in res.json()
+
+
+def test_upload_validation_failure():
+    token = make_token()
+    files = {"file": ("data.xlsx", _build_invalid_workbook(), "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")}
+    res = client.post("/api/uploads", files=files, headers={"Authorization": f"Bearer {token}"})
+    upload_id = res.json()["upload_id"]
+
+    res = client.post(f"/api/uploads/{upload_id}/validate", headers={"Authorization": f"Bearer {token}"})
+    assert res.status_code == 200
+    body = res.json()
+    assert body["status"] == "failed"
+    assert body["errors"]

--- a/backend/migrations/versions/b83fd0664b74_add_template_fields_to_uploads.py
+++ b/backend/migrations/versions/b83fd0664b74_add_template_fields_to_uploads.py
@@ -1,0 +1,72 @@
+"""add template columns to uploads
+
+Revision ID: b83fd0664b74
+Revises: 7329a50dd3fa
+Create Date: 2024-08-24 00:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "b83fd0664b74"
+down_revision: Union[str, None] = "7329a50dd3fa"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("uploads") as batch:
+        batch.add_column(sa.Column("template_version", sa.String(), nullable=True))
+        batch.add_column(sa.Column("errors_json", sa.JSON(), nullable=True))
+        batch.add_column(
+            sa.Column(
+                "updated_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.text("now()"),
+                nullable=True,
+            )
+        )
+        batch.alter_column(
+            "status",
+            existing_type=sa.Enum(
+                "pending",
+                "completed",
+                "failed",
+                name="uploadfilestatus",
+            ),
+            type_=sa.Enum(
+                "pending",
+                "validated",
+                "failed",
+                "ingested",
+                name="uploadfilestatus",
+            ),
+            existing_nullable=False,
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("uploads") as batch:
+        batch.alter_column(
+            "status",
+            existing_type=sa.Enum(
+                "pending",
+                "validated",
+                "failed",
+                "ingested",
+                name="uploadfilestatus",
+            ),
+            type_=sa.Enum(
+                "pending",
+                "completed",
+                "failed",
+                name="uploadfilestatus",
+            ),
+            existing_nullable=False,
+        )
+        batch.drop_column("updated_at")
+        batch.drop_column("errors_json")
+        batch.drop_column("template_version")

--- a/backend/worker/tasks/ingest_excel_or_csv.py
+++ b/backend/worker/tasks/ingest_excel_or_csv.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from typing import Dict, Any
 
 from celery import shared_task
-from worker.tasks.recompute_metrics import recompute_metrics
+from .recompute_metrics import recompute_metrics
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- add template constants and validator for excel uploads
- extend upload model with template fields and status
- add new uploads API endpoints with storage and validation flow
- align template sheet/column names with spec and drop jwt shim

## Testing
- `pytest backend/app/tests/test_uploads_api.py backend/app/tests/test_excel_validator.py -vv`


------
https://chatgpt.com/codex/tasks/task_e_68b0321232f0832b9759bccc711ab601