### PR TITLE
feat(reports): add template-driven report generation

### DIFF
--- a/backend/app/api/routes/__init__.py
+++ b/backend/app/api/routes/__init__.py
@@ -4,7 +4,7 @@ from .users import router as users_router
 from .data import router as data_router
 from .integrations import router as integrations_router
 from .dashboards import router as dashboards_router
-from .reports import router as reports_router
+from .reports import router as reports_router, templates_router as report_templates_router
 from .investors import router as investors_router
 
 __all__ = [
@@ -14,5 +14,6 @@ __all__ = [
     "integrations_router",
     "dashboards_router",
     "reports_router",
+    "report_templates_router",
     "investors_router"
 ]

--- a/backend/app/api/routes/reports.py
+++ b/backend/app/api/routes/reports.py
@@ -1,13 +1,39 @@
 
-from fastapi import APIRouter, Depends, HTTPException
+import os
+from typing import Any, Dict, Optional
+
+from fastapi import (
+    APIRouter,
+    Depends,
+    HTTPException,
+    UploadFile,
+    File,
+    Form,
+    Response,
+)
+from fastapi.security import HTTPAuthorizationCredentials
 from fastapi.responses import FileResponse
+from pydantic import BaseModel
 from sqlalchemy.orm import Session
+
 from ...database import get_db
 from ...models.user import User
-from ...api.deps import get_current_user
-from ...services.report_service import ReportService
+from ...api.deps import get_current_user, verify_token, security
+from ...models.report import (
+    ReportTemplate,
+    ReportJob,
+    ReportJobStatus,
+    ReportEngine,
+)
+from ...storage.s3_client import get_s3_client
 
 router = APIRouter(prefix="/reports", tags=["reports"])
+templates_router = APIRouter(prefix="/report-templates", tags=["report-templates"])
+
+
+class ReportCreateRequest(BaseModel):
+    template_id: int
+    params: Optional[Dict[str, Any]] = None
 
 @router.get("/frameworks")
 async def get_reporting_frameworks():
@@ -19,49 +45,140 @@ async def get_reporting_frameworks():
     ]
     return {"frameworks": frameworks}
 
-@router.post("/generate")
-async def generate_report(
-    framework: str,
-    title: str = "Impact Report",
+@templates_router.post("", status_code=201)
+async def create_report_template(
+    file: UploadFile = File(...),
+    name: str = Form(...),
+    description: str = Form(""),
+    engine: ReportEngine = Form(...),
+    version: int = Form(1),
     current_user: User = Depends(get_current_user),
-    db: Session = Depends(get_db)
+    db: Session = Depends(get_db),
 ):
-    report_service = ReportService()
-    try:
-        report = await report_service.generate_report(
-            current_user.id, framework, title, db
-        )
-        return {"message": "Report generated successfully", "report_id": report.id}
-    except Exception as e:
-        raise HTTPException(status_code=400, detail=str(e))
+    contents = await file.read()
+    template = ReportTemplate(
+        name=name,
+        description=description,
+        engine=engine,
+        object_key="",
+        version=version,
+        created_by=current_user.id,
+    )
+    db.add(template)
+    db.commit()
+    db.refresh(template)
 
-@router.get("/{report_id}")
-async def get_report(
-    report_id: int,
+    key = f"report-templates/{template.id}/{file.filename}"
+    bucket = os.environ["S3_BUCKET"]
+    s3 = get_s3_client()
+    s3.put_object(Bucket=bucket, Key=key, Body=contents, ContentType=file.content_type)
+    template.object_key = key
+    db.commit()
+    return {"template_id": template.id}
+
+
+@templates_router.get("")
+async def list_report_templates(db: Session = Depends(get_db)):
+    templates = db.query(ReportTemplate).all()
+    return {
+        "templates": [
+            {
+                "id": t.id,
+                "name": t.name,
+                "description": t.description,
+                "engine": t.engine.value,
+                "version": t.version,
+            }
+            for t in templates
+        ]
+    }
+
+
+@router.post("", status_code=201)
+async def create_report_job(
+    data: ReportCreateRequest,
     current_user: User = Depends(get_current_user),
-    db: Session = Depends(get_db)
+    creds: HTTPAuthorizationCredentials = Depends(security),
+    db: Session = Depends(get_db),
 ):
-    report_service = ReportService()
-    report = await report_service.get_report(report_id, current_user.id, db)
-    
-    if not report:
+    payload = verify_token(creds.credentials)
+    org_id: Optional[str] = payload.get("org_id") if payload else None
+    if org_id is None:
+        raise HTTPException(status_code=401, detail="Invalid token")
+
+    job = ReportJob(
+        user_id=current_user.id,
+        org_id=str(org_id),
+        template_id=data.template_id,
+        params_json=data.params or {},
+        status=ReportJobStatus.queued,
+    )
+    db.add(job)
+    db.commit()
+    db.refresh(job)
+
+    try:
+        from ...worker.tasks.render_report import render_report_job
+
+        render_report_job.delay(job.id)
+    except Exception:
+        pass
+
+    return {"report_id": job.id}
+
+
+@router.get("/{job_id}")
+async def get_report_job(
+    job_id: int,
+    current_user: User = Depends(get_current_user),
+    creds: HTTPAuthorizationCredentials = Depends(security),
+    db: Session = Depends(get_db),
+):
+    payload = verify_token(creds.credentials)
+    org_id: Optional[str] = payload.get("org_id") if payload else None
+    job = (
+        db.query(ReportJob)
+        .filter(
+            ReportJob.id == job_id,
+            ReportJob.user_id == current_user.id,
+            ReportJob.org_id == str(org_id),
+        )
+        .first()
+    )
+    if job is None:
         raise HTTPException(status_code=404, detail="Report not found")
-    
-    return report
+    return {"status": job.status.value, "error": job.error_json}
 
-@router.get("/{report_id}/download")
-async def download_report(
-    report_id: int,
+
+@router.get("/{job_id}/download")
+async def download_report_job(
+    job_id: int,
     current_user: User = Depends(get_current_user),
-    db: Session = Depends(get_db)
+    creds: HTTPAuthorizationCredentials = Depends(security),
+    db: Session = Depends(get_db),
 ):
-    report_service = ReportService()
-    try:
-        pdf_path = await report_service.generate_pdf(report_id, current_user.id, db)
-        return FileResponse(
-            pdf_path,
-            media_type="application/pdf",
-            filename=f"report_{report_id}.pdf",
+    payload = verify_token(creds.credentials)
+    org_id: Optional[str] = payload.get("org_id") if payload else None
+    job = (
+        db.query(ReportJob)
+        .filter(
+            ReportJob.id == job_id,
+            ReportJob.user_id == current_user.id,
+            ReportJob.org_id == str(org_id),
         )
-    except Exception as e:
-        raise HTTPException(status_code=400, detail=str(e))
+        .first()
+    )
+    if job is None or not job.output_object_key:
+        raise HTTPException(status_code=404, detail="Report not ready")
+
+    bucket = os.environ["S3_BUCKET"]
+    s3 = get_s3_client()
+    obj = s3.get_object(Bucket=bucket, Key=job.output_object_key)
+    content = obj["Body"].read()
+    filename = job.output_object_key.split("/")[-1]
+    media_type = "application/pdf" if filename.endswith(".pdf") else "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+    return Response(
+        content,
+        media_type=media_type,
+        headers={"Content-Disposition": f"attachment; filename={filename}"},
+    )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,11 +4,12 @@ from fastapi.middleware.cors import CORSMiddleware
 from .config import settings
 from .api.routes import (
     auth_router,
-    users_router, 
+    users_router,
     data_router,
     integrations_router,
     dashboards_router,
     reports_router,
+    report_templates_router,
     investors_router
 )
 from .routes.public.template import router as public_template_router
@@ -44,6 +45,7 @@ app.include_router(data_router, prefix="/api/v1")
 app.include_router(integrations_router, prefix="/api/v1")
 app.include_router(dashboards_router, prefix="/api/v1")
 app.include_router(reports_router, prefix="/api/v1")
+app.include_router(report_templates_router, prefix="/api/v1")
 app.include_router(investors_router, prefix="/api/v1")
 app.include_router(public_template_router)
 app.include_router(ingest_upload_router)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -2,7 +2,7 @@ from .user import User
 from .data_upload import DataUpload
 from .dashboard import Dashboard
 from .dashboard_topic import DashboardTopic
-from .report import Report
+from .report import Report, ReportTemplate, ReportJob
 from .project import Project
 from .activity import Activity
 from .outcome import Outcome

--- a/backend/app/models/report.py
+++ b/backend/app/models/report.py
@@ -1,7 +1,10 @@
 
-from sqlalchemy import Column, Integer, String, DateTime, Text, ForeignKey, JSON
+import enum
+
+from sqlalchemy import Column, Integer, String, DateTime, Text, ForeignKey, JSON, Enum
 from sqlalchemy.sql import func
 from sqlalchemy.orm import relationship
+
 from ..database import Base
 from .user import User
 
@@ -20,3 +23,52 @@ class Report(Base):
     created_at = Column(DateTime(timezone=True), server_default=func.now())
 
     user = relationship("User", back_populates="reports")
+
+
+class ReportEngine(str, enum.Enum):
+    html = "html"
+    docx = "docx"
+
+
+class ReportTemplate(Base):
+    __tablename__ = "report_templates"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, nullable=False)
+    description = Column(Text, nullable=True)
+    engine = Column(Enum(ReportEngine, name="reportengine"), nullable=False)
+    object_key = Column(String, nullable=False)
+    version = Column(Integer, nullable=False)
+    created_by = Column(Integer, ForeignKey("users.id"), nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+    creator = relationship("User")
+
+
+class ReportJobStatus(str, enum.Enum):
+    queued = "queued"
+    running = "running"
+    success = "success"
+    failed = "failed"
+
+
+class ReportJob(Base):
+    __tablename__ = "report_jobs"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    org_id = Column(String, nullable=False)
+    template_id = Column(Integer, ForeignKey("report_templates.id"), nullable=False)
+    params_json = Column(JSON, nullable=True)
+    status = Column(
+        Enum(ReportJobStatus, name="reportjobstatus"),
+        nullable=False,
+        default=ReportJobStatus.queued,
+    )
+    output_object_key = Column(String, nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    completed_at = Column(DateTime(timezone=True), nullable=True)
+    error_json = Column(JSON, nullable=True)
+
+    template = relationship("ReportTemplate")
+    user = relationship("User")

--- a/backend/app/reports/templates/pilot_overview.html.j2
+++ b/backend/app/reports/templates/pilot_overview.html.j2
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"><title>{{ title }}</title></head>
+<body>
+<h1>{{ title }}</h1>
+<section>
+  <h2>KPIs</h2>
+  <ul>
+  {% for item in kpis %}
+    <li>{{ item.name }}: {{ item.value }}</li>
+  {% endfor %}
+  </ul>
+</section>
+<section>
+  <h2>Outcomes</h2>
+  <table border="1">
+    <tr><th>Name</th><th>Result</th></tr>
+    {% for o in outcomes %}
+    <tr><td>{{ o.name }}</td><td>{{ o.result }}</td></tr>
+    {% endfor %}
+  </table>
+</section>
+</body>
+</html>

--- a/backend/app/tests/zz_test_report_generation_api.py
+++ b/backend/app/tests/zz_test_report_generation_api.py
@@ -1,0 +1,169 @@
+import os
+import sys
+import io
+import importlib
+from pathlib import Path
+from jose import jwt
+from fastapi.testclient import TestClient
+
+# Setup environment variables
+os.environ["DATABASE_URL"] = "sqlite://"
+os.environ.setdefault("JWT_SECRET", "test")
+os.environ.setdefault("SECRET_KEY", "test")
+os.environ.setdefault("OPENAI_API_KEY", "test")
+os.environ.setdefault("XERO_CLIENT_ID", "test")
+os.environ.setdefault("XERO_CLIENT_SECRET", "test")
+os.environ.setdefault("XERO_REDIRECT_URI", "http://localhost")
+os.environ.setdefault("GOOGLE_CLIENT_ID", "test")
+os.environ.setdefault("GOOGLE_CLIENT_SECRET", "test")
+os.environ.setdefault("GOOGLE_REDIRECT_URI", "http://localhost")
+os.environ.setdefault("S3_BUCKET", "testbucket")
+
+sys.path.append(str(Path(__file__).resolve().parents[3]))
+
+from backend.app.api import deps as deps_module
+from backend.worker.tasks import render_report as render_task
+from backend.app.storage import s3_client as s3_module
+
+client: TestClient
+
+
+class DummyS3:
+    def __init__(self):
+        self.store = {}
+
+    def put_object(self, Bucket, Key, Body, ContentType=None):
+        if isinstance(Body, bytes):
+            data = Body
+        else:
+            data = Body.read()
+        self.store[Key] = data
+
+    def download_file(self, Bucket, Key, Filename):
+        with open(Filename, "wb") as f:
+            f.write(self.store[Key])
+
+    def get_object(self, Bucket, Key):
+        return {"Body": io.BytesIO(self.store[Key])}
+
+
+def setup_function(_):
+    os.environ["DATABASE_URL"] = "sqlite:///./test_report_gen.db"
+    db_path = Path("test_report_gen.db")
+    if db_path.exists():
+        db_path.unlink()
+
+    import backend.app.main as main_module
+    import backend.app.database as db_module
+    import backend.app.models as models
+
+    importlib.reload(main_module)
+    importlib.reload(db_module)
+    importlib.reload(models)
+
+    global client
+    client = TestClient(main_module.app)
+
+    db_module.Base.metadata.drop_all(bind=db_module.engine)
+    db_module.Base.metadata.create_all(bind=db_module.engine)
+    db = db_module.SessionLocal()
+    db.add(models.User(id=1, email="user@example.com", hashed_password="x", name="Test"))
+    db.commit()
+    db.close()
+
+    s3_instance = DummyS3()
+    s3_module.get_s3_client = lambda: s3_instance
+
+    def _run(job_id: int):
+        try:
+            render_task.render_report_job(job_id)
+        except Exception:
+            pass
+
+    render_task.render_report_job.delay = _run
+
+    def _fake_verify(token: str):
+        try:
+            return jwt.decode(token, os.environ["JWT_SECRET"], algorithms=["HS256"])
+        except Exception:
+            return None
+
+    deps_module.verify_token = _fake_verify
+
+
+def make_token(org_id="org1"):
+    payload = {"sub": "1", "type": "access", "org_id": org_id}
+    return jwt.encode(payload, os.environ["JWT_SECRET"], algorithm="HS256")
+
+
+def test_template_upload_and_report_generation():
+    token = make_token()
+    template_path = Path(__file__).resolve().parents[2] / "app/reports/templates/pilot_overview.html.j2"
+    files = {"file": (template_path.name, template_path.read_bytes(), "text/jinja2")}
+    data = {"name": "Pilot", "description": "", "engine": "html", "version": "1"}
+    resp = client.post(
+        "/api/v1/report-templates",
+        files=files,
+        data=data,
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 201
+    template_id = resp.json()["template_id"]
+
+    resp = client.get("/api/v1/report-templates")
+    assert resp.status_code == 200
+    assert any(t["id"] == template_id for t in resp.json()["templates"])
+
+    payload = {
+        "template_id": template_id,
+        "params": {"title": "Hello", "kpis": [{"name": "Impact", "value": 5}], "outcomes": []},
+    }
+    resp = client.post(
+        "/api/v1/reports",
+        json=payload,
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 201
+    report_id = resp.json()["report_id"]
+
+    resp = client.get(
+        f"/api/v1/reports/{report_id}",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.json()["status"] == "success"
+
+    resp = client.get(
+        f"/api/v1/reports/{report_id}/download",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    assert len(resp.content) > 0
+
+
+def test_variable_mismatch_produces_error():
+    token = make_token()
+    template_path = Path(__file__).resolve().parents[2] / "app/reports/templates/pilot_overview.html.j2"
+    files = {"file": (template_path.name, template_path.read_bytes(), "text/jinja2")}
+    data = {"name": "Pilot", "description": "", "engine": "html", "version": "1"}
+    resp = client.post(
+        "/api/v1/report-templates",
+        files=files,
+        data=data,
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    template_id = resp.json()["template_id"]
+
+    payload = {"template_id": template_id, "params": {"title": "Hi"}}
+    resp = client.post(
+        "/api/v1/reports",
+        json=payload,
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    report_id = resp.json()["report_id"]
+
+    resp = client.get(
+        f"/api/v1/reports/{report_id}",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.json()["status"] == "failed"
+    assert "error" in resp.json()["error"]

--- a/backend/migrations/versions/f2c1a5b6d789_add_report_templates_and_jobs.py
+++ b/backend/migrations/versions/f2c1a5b6d789_add_report_templates_and_jobs.py
@@ -1,0 +1,76 @@
+"""add report templates and jobs tables
+
+Revision ID: f2c1a5b6d789
+Revises: d4f6e7c8b9a1
+Create Date: 2025-06-06 00:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "f2c1a5b6d789"
+down_revision: Union[str, None] = "d4f6e7c8b9a1"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "report_templates",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column(
+            "engine",
+            sa.Enum("html", "docx", name="reportengine"),
+            nullable=False,
+        ),
+        sa.Column("object_key", sa.String(), nullable=False),
+        sa.Column("version", sa.Integer(), nullable=False),
+        sa.Column("created_by", sa.Integer(), sa.ForeignKey("users.id"), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+    )
+
+    op.create_table(
+        "report_jobs",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("user_id", sa.Integer(), sa.ForeignKey("users.id"), nullable=False),
+        sa.Column("org_id", sa.String(), nullable=False),
+        sa.Column(
+            "template_id",
+            sa.Integer(),
+            sa.ForeignKey("report_templates.id"),
+            nullable=False,
+        ),
+        sa.Column("params_json", sa.JSON(), nullable=True),
+        sa.Column(
+            "status",
+            sa.Enum("queued", "running", "success", "failed", name="reportjobstatus"),
+            nullable=False,
+            server_default="queued",
+        ),
+        sa.Column("output_object_key", sa.String(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("error_json", sa.JSON(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("report_jobs")
+    op.drop_table("report_templates")
+    op.execute("DROP TYPE IF EXISTS reportjobstatus")
+    op.execute("DROP TYPE IF EXISTS reportengine")

--- a/backend/worker/tasks/render_report.py
+++ b/backend/worker/tasks/render_report.py
@@ -1,0 +1,88 @@
+import os
+from datetime import datetime
+from tempfile import NamedTemporaryFile
+from typing import Dict
+
+from celery import shared_task
+from jinja2 import Template, StrictUndefined
+
+
+@shared_task(name="render_report")
+def render_report_job(job_id: int) -> Dict[str, str]:
+    """Render a report job defined in the database."""
+    from backend.app.database import SessionLocal
+    from backend.app.models.report import ReportJob, ReportTemplate, ReportJobStatus
+    from backend.app.storage.s3_client import get_s3_client
+
+    db = SessionLocal()
+    job = db.query(ReportJob).filter(ReportJob.id == job_id).first()
+    if job is None:
+        db.close()
+        return {"status": "missing"}
+
+    template = db.query(ReportTemplate).filter(ReportTemplate.id == job.template_id).first()
+    bucket = os.environ.get("S3_BUCKET")
+    s3 = get_s3_client()
+
+    try:
+        job.status = ReportJobStatus.running
+        db.commit()
+
+        with NamedTemporaryFile(delete=False) as tmp:
+            if bucket:
+                s3.download_file(bucket, template.object_key, tmp.name)
+            else:
+                s3.download_file(None, template.object_key, tmp.name)  # type: ignore[arg-type]
+            template_path = tmp.name
+
+        if template.engine.value == "html":
+            with open(template_path, "r", encoding="utf-8") as f:
+                tpl = Template(f.read(), undefined=StrictUndefined)
+            html = tpl.render(job.params_json or {})
+            with NamedTemporaryFile(delete=False, suffix=".pdf") as out:
+                try:
+                    from weasyprint import HTML  # type: ignore
+
+                    HTML(string=html).write_pdf(out.name)
+                except Exception:
+                    from reportlab.pdfgen import canvas
+                    from reportlab.lib.pagesizes import letter
+
+                    c = canvas.Canvas(out.name, pagesize=letter)
+                    c.drawString(40, 750, html[:1000])
+                    c.save()
+                output_path = out.name
+            key = f"reports/{job.id}.pdf"
+            with open(output_path, "rb") as data:
+                s3.put_object(Bucket=bucket, Key=key, Body=data.read(), ContentType="application/pdf")
+        else:
+            from docxtpl import DocxTemplate  # type: ignore
+
+            doc = DocxTemplate(template_path)
+            doc.render(job.params_json or {})
+            with NamedTemporaryFile(delete=False, suffix=".docx") as out:
+                doc.save(out.name)
+                output_path = out.name
+            key = f"reports/{job.id}.docx"
+            with open(output_path, "rb") as data:
+                s3.put_object(
+                    Bucket=bucket,
+                    Key=key,
+                    Body=data.read(),
+                    ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                )
+
+        job.status = ReportJobStatus.success
+        job.output_object_key = key
+        job.completed_at = datetime.utcnow()
+        db.commit()
+        return {"status": "success", "key": key}
+    except Exception as exc:  # pragma: no cover
+        db.rollback()
+        job.status = ReportJobStatus.failed
+        job.error_json = {"error": str(exc)}
+        job.completed_at = datetime.utcnow()
+        db.commit()
+        raise
+    finally:
+        db.close()

--- a/backend/worker/worker.py
+++ b/backend/worker/worker.py
@@ -59,4 +59,9 @@ def _on_worker_shutdown(**_):
     log_event("worker_shutdown", org_id=ORG_ID, project_id=PROJECT_ID)
 
 # Ensure tasks are registered
-from .tasks import ingest_excel_or_csv, recompute_metrics, cleanup_beneficiaries  # noqa: F401
+from .tasks import (
+    ingest_excel_or_csv,
+    recompute_metrics,
+    cleanup_beneficiaries,
+    render_report,
+)  # noqa: F401


### PR DESCRIPTION
## Summary
- add database models and migration for report templates and jobs
- support uploading templates and generating reports via new endpoints
- add Celery task to render reports and store output in S3

## Testing
- `pytest` *(fails: sqlite3.OperationalError: attempt to write a readonly database)*

------
https://chatgpt.com/codex/tasks/task_e_68b03c768370832bbd6c70b63fe89332